### PR TITLE
Disable Actions in RomBrowser ContextMenu when not needed

### DIFF
--- a/Source/RMG/UserInterface/Widget/RomBrowserWidget.cpp
+++ b/Source/RMG/UserInterface/Widget/RomBrowserWidget.cpp
@@ -150,7 +150,7 @@ void RomBrowserWidget::contextMenu_Actions_Connect(void)
 
 void RomBrowserWidget::contextMenu_Actions_Update(void)
 {
-    bool enabled =  this->selectedIndexes().count() > 0;
+    bool enabled = this->selectedIndexes().count() > 0;
 
     this->action_PlayGame->setEnabled(enabled);
     this->action_PlayGameWithDisk->setEnabled(enabled);

--- a/Source/RMG/UserInterface/Widget/RomBrowserWidget.cpp
+++ b/Source/RMG/UserInterface/Widget/RomBrowserWidget.cpp
@@ -148,6 +148,17 @@ void RomBrowserWidget::contextMenu_Actions_Connect(void)
     connect(this->action_EditCheats, &QAction::triggered, this, &RomBrowserWidget::on_Action_EditCheats);
 }
 
+void RomBrowserWidget::contextMenu_Actions_Update(void)
+{
+    bool enabled =  this->selectedIndexes().count() > 0;
+
+    this->action_PlayGame->setEnabled(enabled);
+    this->action_PlayGameWithDisk->setEnabled(enabled);
+    this->action_RomInformation->setEnabled(enabled);
+    this->action_EditGameSettings->setEnabled(enabled);
+    this->action_EditCheats->setEnabled(enabled);
+}
+
 void RomBrowserWidget::model_Init(void)
 {
     this->model_Model = new QStandardItemModel(this);
@@ -316,6 +327,7 @@ void RomBrowserWidget::dropEvent(QDropEvent *event)
 
 void RomBrowserWidget::customContextMenuRequested(QPoint position)
 {
+    this->contextMenu_Actions_Update();
     this->contextMenu->popup(this->viewport()->mapToGlobal(position));
 }
 

--- a/Source/RMG/UserInterface/Widget/RomBrowserWidget.hpp
+++ b/Source/RMG/UserInterface/Widget/RomBrowserWidget.hpp
@@ -60,6 +60,7 @@ class RomBrowserWidget : public QTableView
     void contextMenu_Actions_Init(void);
     void contextMenu_Actions_Setup(void);
     void contextMenu_Actions_Connect(void);
+    void contextMenu_Actions_Update(void);
 
     QStandardItemModel *model_Model;
     std::vector<int> model_Columns;


### PR DESCRIPTION
If no ROM is selected, the Actions that refer to a selected ROM are disabled now. This also fixes a Crash when Play Game is clicked without a ROM selected.