### PR TITLE
Add 2 categories

### DIFF
--- a/Package/com.github.Rosalie241.RMG.appdata.xml
+++ b/Package/com.github.Rosalie241.RMG.appdata.xml
@@ -41,6 +41,8 @@
   <url type="bugtracker">https://github.com/Rosalie241/RMG/issues</url>
   <categories>
     <category>Game</category>
+    <category>Emulator</category>
+    <category>Qt</category>
   </categories>
   <recommends>
     <control>pointing</control>

--- a/Package/com.github.Rosalie241.RMG.desktop
+++ b/Package/com.github.Rosalie241.RMG.desktop
@@ -5,4 +5,4 @@ Comment=An easy to use & cross-platform mupen64plus front-end written in C++ & Q
 Exec=RMG
 Icon=com.github.Rosalie241.RMG
 Terminal=false
-Categories=Game;
+Categories=Game;Emulator;Qt;


### PR DESCRIPTION
This PR just add 2 categories. The Emulator category (subcategory of Game) is needed to make RMG appear in the Emulator section of the Software centers. The Qt category just shows, that this Program uses a Qt GUI.