### PR TITLE
Add MimeType to .desktop

### DIFF
--- a/Package/com.github.Rosalie241.RMG.desktop
+++ b/Package/com.github.Rosalie241.RMG.desktop
@@ -6,3 +6,4 @@ Exec=RMG %f
 Icon=com.github.Rosalie241.RMG
 Terminal=false
 Categories=Game;Emulator;Qt;
+MimeType=application/x-n64-rom;


### PR DESCRIPTION
This just tells the File managers, that RMG can open Nintendo 64 ROM files, so RMG will appear direct in the open with list of Nintendo 64 ROM files by default.