### PR TITLE
Add missing STL includes and remove redundant and unused ones

### DIFF
--- a/Source/RMG-Audio/main.cpp
+++ b/Source/RMG-Audio/main.cpp
@@ -11,6 +11,9 @@
 #define M64P_PLUGIN_PROTOTYPES 1
 #define AUDIO_PLUGIN_API_VERSION 0x020100
 
+#include <cstdint>
+#include <cstdlib>
+
 #include <SDL.h>
 #include <SDL_audio.h>
 

--- a/Source/RMG-Core/Core.cpp
+++ b/Source/RMG-Core/Core.cpp
@@ -14,6 +14,7 @@
 #include "m64p/Api.hpp"
 #include "m64p/api/version.h"
 #include <filesystem>
+#include <string>
 
 //
 // Local Variables

--- a/Source/RMG-Core/Directories.cpp
+++ b/Source/RMG-Core/Directories.cpp
@@ -14,6 +14,7 @@
 #include "m64p/Api.hpp"
 
 #include <cstdio>
+#include <cstdlib>
 #include <iostream>
 #include <filesystem>
 

--- a/Source/RMG-Core/Key.cpp
+++ b/Source/RMG-Core/Key.cpp
@@ -11,6 +11,8 @@
 #include "Error.hpp"
 #include "m64p/Api.hpp"
 
+#include <string>
+
 //
 // Exported Functions
 //

--- a/Source/RMG-Core/MediaLoader.cpp
+++ b/Source/RMG-Core/MediaLoader.cpp
@@ -13,6 +13,7 @@
 
 #include "m64p/Api.hpp"
 
+#include <cstdint>
 #include <cstring>
 
 //

--- a/Source/RMG-Core/Plugins.cpp
+++ b/Source/RMG-Core/Plugins.cpp
@@ -21,7 +21,6 @@
 #include "m64p/Api.hpp"
 
 #include <filesystem>
-#include <string>
 
 //
 // Local Variables

--- a/Source/RMG-Core/Rom.cpp
+++ b/Source/RMG-Core/Rom.cpp
@@ -13,8 +13,8 @@
 #include "RomSettings.hpp"
 
 #include <unzip.h>
-#include <iostream>
 #include <fstream>
+#include <cstdlib>
 #include <cstring>
 
 //

--- a/Source/RMG-Core/RomHeader.hpp
+++ b/Source/RMG-Core/RomHeader.hpp
@@ -10,7 +10,7 @@
 #ifndef CORE_ROMHEADER_HPP
 #define CORE_ROMHEADER_HPP
 
-#include <cinttypes>
+#include <cstdint>
 #include <string>
 
 struct CoreRomHeader

--- a/Source/RMG-Core/RomSettings.hpp
+++ b/Source/RMG-Core/RomSettings.hpp
@@ -10,7 +10,7 @@
 #ifndef CORE_ROMSETTINGS_HPP
 #define CORE_ROMSETTINGS_HPP
 
-#include <cinttypes>
+#include <cstdint>
 #include <string>
 
 struct CoreRomSettings

--- a/Source/RMG-Core/Screenshot.cpp
+++ b/Source/RMG-Core/Screenshot.cpp
@@ -11,6 +11,8 @@
 #include "m64p/Api.hpp"
 #include "Error.hpp"
 
+#include <string>
+
 //
 // Exported Functions
 //

--- a/Source/RMG-Core/Settings/Settings.cpp
+++ b/Source/RMG-Core/Settings/Settings.cpp
@@ -14,8 +14,6 @@
 #include "Error.hpp"
 #include "m64p/api/m64p_types.h"
 
-#include <exception>
-#include <string>
 #include <sstream>
 #include <algorithm>
 

--- a/Source/RMG-Core/SpeedLimiter.cpp
+++ b/Source/RMG-Core/SpeedLimiter.cpp
@@ -12,6 +12,8 @@
 
 #include "m64p/Api.hpp"
 
+#include <string>
+
 //
 // Exported Functions
 //

--- a/Source/RMG-Core/VidExt.cpp
+++ b/Source/RMG-Core/VidExt.cpp
@@ -12,6 +12,8 @@
 
 #include "m64p/Api.hpp"
 
+#include <string>
+
 //
 // Exported Functions
 //

--- a/Source/RMG-Core/Video.cpp
+++ b/Source/RMG-Core/Video.cpp
@@ -12,6 +12,8 @@
 #include "Error.hpp"
 #include "m64p/Api.hpp"
 
+#include <string>
+
 //
 // Exported Functions
 //

--- a/Source/RMG/Callbacks.hpp
+++ b/Source/RMG/Callbacks.hpp
@@ -14,6 +14,8 @@
 
 #include <RMG-Core/Core.hpp>
 
+#include <string>
+
 class CoreCallbacks : public QObject
 {
     Q_OBJECT

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.hpp
@@ -10,6 +10,9 @@
 #ifndef SETTINGSDIALOG_HPP
 #define SETTINGSDIALOG_HPP
 
+#include <string>
+#include <vector>
+
 #include <QDialog>
 #include <QHBoxLayout>
 #include <QStandardItemModel>

--- a/Source/RMG/UserInterface/Widget/OGLWidget.cpp
+++ b/Source/RMG/UserInterface/Widget/OGLWidget.cpp
@@ -1,9 +1,8 @@
 #include "OGLWidget.hpp"
 
-using namespace UserInterface::Widget;
-
-#include <iostream>
 #include <RMG-Core/Core.hpp>
+
+using namespace UserInterface::Widget;
 
 OGLWidget::OGLWidget(QWidget *parent)
 {

--- a/Source/RMG/UserInterface/Widget/RomBrowserWidget.cpp
+++ b/Source/RMG/UserInterface/Widget/RomBrowserWidget.cpp
@@ -15,6 +15,8 @@
 #include <QDir>
 #include <QDragMoveEvent>
 
+#include <vector>
+
 using namespace UserInterface::Widget;
 
 static QString columnIdToText(QString file, CoreRomHeader header, CoreRomSettings settings, ColumnID id)


### PR DESCRIPTION
This should prevent any issues like #42 occurring again due to changes in STL implementations or refactors of RMG.

## Summary of changes

#### Soruce/RMG-Audio/main.cpp:
 * `<cstdlib>` for `malloc()`, `free()`
 * `<cstdint>` for `uint8_t`

#### Source/RMG-Core/Core.cpp:
 * `<string>` for `std::string`

#### Source/RMG-Core/Directories.cpp:
 * `<cstdlib>` for `std::getenv()`

#### Source/RMG-Core/Key.cpp:
 * `<string>` for `std::string`

#### Source/RMG-Core/MediaLoader.cpp:
 * `<cstdint>` for `uint8_t`

#### Source/RMG-Core/Plugins.cpp:
 * redundant `<string>` as it is included in the associated header

#### Source/RMG-Core/Rom.cpp:
 * `<cstdlib>` for `malloc()`, `free()`
 * remove unused `<iostream>`

#### Source/RMG-Core/RomHeader.hpp:
 * change `<cinttypes>` to `<cstdint>` because extras aren't used

#### Source/RMG-Core/RomSettings.hpp:
 * change `<cinttypes>` to `<cstdint>` because extras aren't used

#### Source/RMG-Core/Screenshot.cpp:
 * `<string>` for `std::string`

#### Source/RMG-Core/Settings/Settings.cpp:
 * remove unused `<exception>`
 * remove redundant `<string>` as it is included in the associated header

#### Source/RMG-Core/SpeedLimiter.cpp:
 * `<string>` for `std::string`

#### Source/RMG-Core/VidExt.cpp:
 * `<string>` for `std::string`

#### Source/RMG-Core/Video.cpp:
 * `<string>` for `std::string`

#### Source/RMG/Callbacks.hpp:
 * `<string>` for `std::string`

#### Source/RMG/UserInterface/Dialog/SettingsDialog.hpp:
 * `<string>` for `std::string`
 * `<vector>` for `std::vector`

#### Source/RMG/UserInterface/Widget/OGLWidget.cpp:
 * remove unused `<iostream>`

#### Source/RMG/UserInterface/Widget/RomBrowserWidget.cpp:
 * `<vector>` for `std::vector`
