### PR TITLE
SettingsDialog: Minor fixes

### DIFF
--- a/Source/RMG-Core/Settings/Settings.cpp
+++ b/Source/RMG-Core/Settings/Settings.cpp
@@ -266,7 +266,7 @@ static l_Setting get_setting(SettingsID settingId)
         setting = {SETTING_SECTION_64DD, "64DD_DevelopmentIPL", ""};
         break;
     case SettingsID::Core_64DD_SaveDiskFormat:
-        setting = {SETTING_SECTION_M64P, "SaveDiskFormat", 0};
+        setting = {SETTING_SECTION_M64P, "SaveDiskFormat", 1};
         break;
 
     case SettingsID::Game_DisableExtraMem:

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
@@ -732,7 +732,7 @@ void SettingsDialog::chooseIPLRom(QLineEdit *lineEdit)
 {
     QString file;
 
-    file = QFileDialog::getOpenFileName(this, "", "", "IPL ROMs (*.n64)");
+    file = QFileDialog::getOpenFileName(this, "", "", "IPL ROMs (*.n64 *.v64 *.z64)");
     if (file.isEmpty())
     {
         return;


### PR DESCRIPTION
SettingsDialog: Extend IPL ROM extensions
IPL ROMs use the same extensions as basic N64 ROMs.

SettingsDialog: Fix default saveDiskFormat
Clicking the button to `Restore Defaults` results in the wrong value for the `saveDiskFormat`. Default is `RAM Area Only` (1).