### PR TITLE
RMG: Remove setting for Shared Data Directory

### DIFF
--- a/Source/RMG-Core/Settings/Settings.cpp
+++ b/Source/RMG-Core/Settings/Settings.cpp
@@ -252,9 +252,6 @@ static l_Setting get_setting(SettingsID settingId)
     case SettingsID::Core_SaveSRAMPath:
         setting = {SETTING_SECTION_M64P, "SaveSRAMPath", CoreGetDefaultSaveDirectory(), "", true};
         break;
-    case SettingsID::Core_SharedDataPath:
-        setting = {SETTING_SECTION_M64P, "SharedDataPath", CoreGetSharedDataDirectory(), "", true};
-        break;
 
     case SettingsID::Core_64DD_JapaneseIPL:
         setting = {SETTING_SECTION_64DD, "64DD_JapaneseIPL", ""};

--- a/Source/RMG-Core/Settings/SettingsID.hpp
+++ b/Source/RMG-Core/Settings/SettingsID.hpp
@@ -52,7 +52,6 @@ enum class SettingsID
     Core_ScreenshotPath,
     Core_SaveStatePath,
     Core_SaveSRAMPath,
-    Core_SharedDataPath,
 
     // Game Specific Settings
     Game_DisableExtraMem,

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.cpp
@@ -271,7 +271,6 @@ void SettingsDialog::loadDirectorySettings(void)
     static std::string screenshotDir;
     static std::string saveStateDir;
     static std::string saveSramDir;
-    static std::string sharedDataDir;
     static bool overrideUserDirs = false;
     static std::string userDataDir;
     static std::string userCacheDir;
@@ -279,7 +278,6 @@ void SettingsDialog::loadDirectorySettings(void)
     screenshotDir = CoreSettingsGetStringValue(SettingsID::Core_ScreenshotPath);
     saveStateDir = CoreSettingsGetStringValue(SettingsID::Core_SaveStatePath);
     saveSramDir = CoreSettingsGetStringValue(SettingsID::Core_SaveSRAMPath);
-    sharedDataDir = CoreSettingsGetStringValue(SettingsID::Core_SharedDataPath);
 
     overrideUserDirs = CoreSettingsGetBoolValue(SettingsID::Core_OverrideUserDirs);
     userDataDir = CoreSettingsGetStringValue(SettingsID::Core_UserDataDirOverride);
@@ -288,7 +286,6 @@ void SettingsDialog::loadDirectorySettings(void)
     this->screenshotDirLineEdit->setText(QString::fromStdString(screenshotDir));
     this->saveStateDirLineEdit->setText(QString::fromStdString(saveStateDir));
     this->saveSramDirLineEdit->setText(QString::fromStdString(saveSramDir));
-    this->sharedDataDirLineEdit->setText(QString::fromStdString(sharedDataDir));
     this->overrideUserDirsGroupBox->setChecked(overrideUserDirs);
     this->userDataDirLineEdit->setText(QString::fromStdString(userDataDir));
     this->userCacheDirLineEdit->setText(QString::fromStdString(userCacheDir));
@@ -409,7 +406,6 @@ void SettingsDialog::loadDefaultDirectorySettings(void)
     this->screenshotDirLineEdit->setText(QString::fromStdString(CoreSettingsGetDefaultStringValue(SettingsID::Core_ScreenshotPath)));
     this->saveStateDirLineEdit->setText(QString::fromStdString(CoreSettingsGetDefaultStringValue(SettingsID::Core_SaveStatePath)));
     this->saveSramDirLineEdit->setText(QString::fromStdString(CoreSettingsGetDefaultStringValue(SettingsID::Core_SaveSRAMPath)));
-    this->sharedDataDirLineEdit->setText(QString::fromStdString(CoreSettingsGetDefaultStringValue(SettingsID::Core_SharedDataPath)));
     this->overrideUserDirsGroupBox->setChecked(CoreSettingsGetDefaultBoolValue(SettingsID::Core_OverrideUserDirs));
     this->userDataDirLineEdit->setText(QString::fromStdString(CoreSettingsGetDefaultStringValue(SettingsID::Core_UserDataDirOverride)));
     this->userCacheDirLineEdit->setText(QString::fromStdString(CoreSettingsGetDefaultStringValue(SettingsID::Core_UserCacheDirOverride)));
@@ -572,7 +568,6 @@ void SettingsDialog::saveDirectorySettings(void)
     CoreSettingsSetValue(SettingsID::Core_ScreenshotPath, this->screenshotDirLineEdit->text().toStdString());
     CoreSettingsSetValue(SettingsID::Core_SaveStatePath, this->saveStateDirLineEdit->text().toStdString());
     CoreSettingsSetValue(SettingsID::Core_SaveSRAMPath, this->saveSramDirLineEdit->text().toStdString());
-    CoreSettingsSetValue(SettingsID::Core_SharedDataPath, this->sharedDataDirLineEdit->text().toStdString());
 
     CoreSettingsSetValue(SettingsID::Core_OverrideUserDirs, this->overrideUserDirsGroupBox->isChecked());
     CoreSettingsSetValue(SettingsID::Core_UserDataDirOverride, this->userDataDirLineEdit->text().toStdString());
@@ -802,11 +797,6 @@ void SettingsDialog::on_changeSaveStateDirButton_clicked(void)
 void SettingsDialog::on_changeSaveSramDirButton_clicked(void)
 {
     this->chooseDirectory(this->saveSramDirLineEdit);
-}
-
-void SettingsDialog::on_changeSharedDataDirButton_clicked(void)
-{
-    this->chooseDirectory(this->sharedDataDirLineEdit);
 }
 
 void SettingsDialog::on_changeUserDataDirButton_clicked(void)

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.hpp
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.hpp
@@ -96,7 +96,6 @@ class SettingsDialog : public QDialog, private Ui::SettingsDialog
     void on_changeScreenShotDirButton_clicked(void);
     void on_changeSaveStateDirButton_clicked(void);
     void on_changeSaveSramDirButton_clicked(void);
-    void on_changeSharedDataDirButton_clicked(void);
     void on_changeUserDataDirButton_clicked(void);
     void on_changeUserCacheDirButton_clicked(void);
 

--- a/Source/RMG/UserInterface/Dialog/SettingsDialog.ui
+++ b/Source/RMG/UserInterface/Dialog/SettingsDialog.ui
@@ -983,29 +983,6 @@
             </widget>
            </item>
            <item>
-            <widget class="QGroupBox" name="groupBox_29">
-             <property name="title">
-              <string>Shared Data Directory</string>
-             </property>
-             <layout class="QHBoxLayout" name="horizontalLayout_66">
-              <item>
-               <widget class="QLineEdit" name="sharedDataDirLineEdit">
-                <property name="readOnly">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="changeSharedDataDirButton">
-                <property name="text">
-                 <string>Change</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
             <widget class="QGroupBox" name="overrideUserDirsGroupBox">
              <property name="enabled">
               <bool>true</bool>


### PR DESCRIPTION
Shared Data Directory is read only, thus changing it isn't particularly useful for the user.