### PR TITLE
3rdParty: Remove postfix for cxd4 RSP

### DIFF
--- a/Source/3rdParty/CMakeLists.txt
+++ b/Source/3rdParty/CMakeLists.txt
@@ -84,7 +84,7 @@ ExternalProject_Add(mupen64plus-rsp-cxd4
     GIT_REPOSITORY ${MUPEN64PLUS_RSP_CXD4_URL}
     GIT_TAG ${MUPEN64PLUS_RSP_CXD4_TAG}
 
-    BUILD_COMMAND make all APIDIR=${APIDIR} DEBUG=$<CONFIG:Debug> SSE=none
+    BUILD_COMMAND make all APIDIR=${APIDIR} DEBUG=$<CONFIG:Debug> POSTFIX=
     BUILD_IN_SOURCE False
 
     BINARY_DIR ${THIRDPARTY_DIR}/mupen64plus-rsp-cxd4/projects/unix


### PR DESCRIPTION
Keep the binary name consistent and let it choose the instruction set (SSE2 or no SSE) automatically.