### PR TITLE
RMG-Input: implement octagonal input range

### DIFF
--- a/Source/RMG-Input/CMakeLists.txt
+++ b/Source/RMG-Input/CMakeLists.txt
@@ -27,6 +27,7 @@ set(RMG_INPUT_SOURCES
     Utilities/QtKeyToSdl2Key.cpp
     Utilities/InputDevice.cpp
     Thread/SDLThread.cpp
+    common.cpp
     main.cpp
 )
 

--- a/Source/RMG-Input/UserInterface/Widget/ControllerImageWidget.cpp
+++ b/Source/RMG-Input/UserInterface/Widget/ControllerImageWidget.cpp
@@ -170,23 +170,18 @@ void ControllerImageWidget::paintEvent(QPaintEvent *event)
     const double maxOffsetx = maxOffsety;
     const double dist = sqrt(pow(this->xAxisState, 2) + pow(this->yAxisState, 2));
 
-    // take deadzone into account
-    if (dist > this->deadzoneValue)
-    {
-        offsetx = (maxOffsetx / 100 * this->xAxisState);
-        offsety = (maxOffsety / 100 * this->yAxisState);
-    }
+    int octagonX = 0, octagonY = 0;
+    simulateOctagon(
+        this->xAxisState / 100.0, // inputX
+        this->yAxisState / 100.0, // inputY
+        this->deadzoneValue / 100.0, // deadzoneFactor
+        this->rangeValue / 100.0, // scalingFactor
+        octagonX, // outputX
+        octagonY // outputY
+    );
 
-    // take circle range into account
-    if (dist > 100)
-    {
-        offsetx = (maxOffsetx / 100 * (this->xAxisState / dist * 100));
-        offsety = (maxOffsety / 100 * (this->yAxisState / dist * 100));
-    }
-
-    // take range into account
-    offsetx = offsetx / 100 * this->rangeValue;
-    offsety = offsety / 100 * this->rangeValue;
+    offsetx = octagonX * (maxOffsetx / N64_AXIS_PEAK);
+    offsety = octagonY * (maxOffsety / N64_AXIS_PEAK);
 
     // adjust rect with offset
     rectF.adjust(

--- a/Source/RMG-Input/UserInterface/Widget/ControllerWidget.cpp
+++ b/Source/RMG-Input/UserInterface/Widget/ControllerWidget.cpp
@@ -923,7 +923,7 @@ void ControllerWidget::SaveDefaultSettings()
     CoreSettingsSetValue(SettingsID::Input_DeviceName, section, std::string("Keyboard"));
     CoreSettingsSetValue(SettingsID::Input_DeviceNum, section, -1);
     CoreSettingsSetValue(SettingsID::Input_Range, section, 100);
-    CoreSettingsSetValue(SettingsID::Input_Deadzone, section, 15);
+    CoreSettingsSetValue(SettingsID::Input_Deadzone, section, 9);
     CoreSettingsSetValue(SettingsID::Input_Pak, section, 0);
     CoreSettingsSetValue(SettingsID::Input_RemoveDuplicateMappings, section, true);
 

--- a/Source/RMG-Input/common.cpp
+++ b/Source/RMG-Input/common.cpp
@@ -1,0 +1,67 @@
+#include "common.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#define MAX_DIAGONAL_VALUE 69
+#define DEADZONE_VALUE 7
+
+double simulateDeadzone(double n64InputAxis, double maxAxis, int deadzone, double axisRange)
+{
+    double axisAbsolute = std::abs(n64InputAxis);
+
+    if (axisAbsolute < deadzone)
+    {
+        axisAbsolute = 0; // No input when inside deadzone
+    }
+    else
+    {
+        // Create linear scaling factor from 0 at inner deadzone to MAX_AXIS at outer limit
+        axisAbsolute = (axisAbsolute - deadzone) * maxAxis / axisRange / axisAbsolute;
+    }
+
+    return axisAbsolute;
+}
+
+// Credit: MerryMage
+void simulateOctagon(double inputX, double inputY, double deadzoneFactor, double scalingFactor, int& outputX, int& outputY)
+{
+    double maxAxis = scalingFactor * N64_AXIS_PEAK;
+    double maxDiagonal = scalingFactor * MAX_DIAGONAL_VALUE;
+    int deadzone = static_cast<int>(deadzoneFactor * N64_AXIS_PEAK);
+    double axisRange = maxAxis - deadzone;
+    // scale to [-maxAxis, maxAxis]
+    double ax = inputX * maxAxis;
+    double ay = inputY * maxAxis;
+
+    // check whether (ax, ay) is within the circle of radius MAX_AXIS
+    if (double len = std::sqrt(ax*ax + ay*ay); len <= maxAxis)
+    {
+        // scale inputs
+        ax *= simulateDeadzone(ax, maxAxis, deadzone, axisRange);
+        ay *= simulateDeadzone(ay, maxAxis, deadzone, axisRange);
+    }
+    else
+    {
+        // scale ax and ay to stay on the same line, but at the edge of the circle
+        len = maxAxis / len;
+        ax *= len;
+        ay *= len;
+    }
+
+    // bound diagonals to an octagonal range [-69, 69]
+    if (ax != 0.0 && ay != 0.0)
+    {
+        double slope = ay / ax;
+        double edgex = copysign(maxAxis / (std::abs(slope) + (maxAxis - maxDiagonal) / maxDiagonal), ax);
+        double edgey = copysign(std::min(std::abs(edgex * slope), maxAxis / (1.0 / std::abs(slope) + (maxAxis - maxDiagonal) / maxDiagonal)), ay);
+        edgex = edgey / slope;
+
+        double scale = std::sqrt(edgex*edgex + edgey*edgey) / maxAxis;
+        ax *= scale;
+        ay *= scale;
+    }
+
+    outputX = static_cast<int>(ax);
+    outputY = static_cast<int>(ay);
+}

--- a/Source/RMG-Input/common.hpp
+++ b/Source/RMG-Input/common.hpp
@@ -11,6 +11,7 @@
 #define COMMON_HPP
 
 #define SDL_AXIS_PEAK 32767
+#define N64_AXIS_PEAK  85
 
 enum class N64ControllerButton
 {
@@ -57,5 +58,7 @@ enum class N64ControllerPak
     TransferPak,
     None,
 };
+
+void simulateOctagon(double inputX, double inputY, double deadzoneFactor, double scalingFactor, int& outputX, int& outputY);
 
 #endif // COMMON_HPP


### PR DESCRIPTION
The implementation takes configured deadzone and range into account, with 9% deadzone equating to the real N64 deadzone.

Implementation based on [fzurita's in mupen64plus-ae](https://github.com/mupen64plus-ae/mupen64plus-ae/blob/cea9d99c3c7f908cfdb3d81f254854c47981b7b6/mupen64plus-input-android/src/plugin.cpp#L322-L369), which in turn is based on [MerryMage's, with deadzone by kev4cards in ares](https://github.com/ares-emulator/ares/blob/master/ares/n64/controller/gamepad/gamepad.cpp#L192-L229).