### PR TITLE
RMG: Add "Graphics" and "Input" as options to toolbar

### DIFF
--- a/Source/RMG/UserInterface/MainWindow.ui
+++ b/Source/RMG/UserInterface/MainWindow.ui
@@ -157,6 +157,9 @@
    <addaction name="action_View_Fullscreen"/>
    <addaction name="separator"/>
    <addaction name="action_Settings_Settings"/>
+   <addaction name="separator"/>
+   <addaction name="action_Settings_Graphics"/>
+   <addaction name="action_Settings_Input"/>
   </widget>
   <action name="action_System_StartRom">
    <property name="icon">


### PR DESCRIPTION
I find it pretty annoying having to go to the tiny menu bar ribbon at the top of the screen whenever I want to change my plugin settings, so I added shortcuts to the "Graphics" and "Input" menus on the toolbar. I considered adding "Audio" and "RSP" too, but that just looked too cluttered, and most people probably aren't going to be tinkering with them as much as "Graphics" and "Input", so I ultimately decided to leave them out.

I've included some screenshots below to give you an idea of what the toolbar looks like with these options added:

![RMG_Window_1](https://user-images.githubusercontent.com/70489593/213965653-bb0ca39d-72c0-4345-b089-4983082f978d.png)
![RMG_Window_2](https://user-images.githubusercontent.com/70489593/213965660-2bae60f6-0346-4215-b484-01efe2751787.png)
![RMG_Maximized](https://user-images.githubusercontent.com/70489593/213965666-dafc16ef-6081-44b0-90ae-ecf95222f9de.png)