### PR TITLE
"Game List" Mode Overhaul: Phase 3

### DIFF
--- a/Source/RMG-Core/CachedRomHeaderAndSettings.cpp
+++ b/Source/RMG-Core/CachedRomHeaderAndSettings.cpp
@@ -37,7 +37,7 @@
 #define GOODNAME_LEN 256
 #define MD5_LEN 33
 #define GAMEID_LEN 5
-#define REGION_LEN 20
+#define REGION_LEN 18
 
 #ifdef _WIN32
 #define CACHE_FILE_MAGIC "RMGCoreHeaderAndSettingsCacheWindows_06"

--- a/Source/RMG-Core/CachedRomHeaderAndSettings.cpp
+++ b/Source/RMG-Core/CachedRomHeaderAndSettings.cpp
@@ -36,11 +36,13 @@
 #define ROMHEADER_NAME_LEN 256
 #define GOODNAME_LEN 256
 #define MD5_LEN 33
+#define GAMEID_LEN 5
+#define REGION_LEN 20
 
 #ifdef _WIN32
-#define CACHE_FILE_MAGIC "RMGCoreHeaderAndSettingsCacheWindows_05"
+#define CACHE_FILE_MAGIC "RMGCoreHeaderAndSettingsCacheWindows_06"
 #else // Linux
-#define CACHE_FILE_MAGIC "RMGCoreHeaderAndSettingsCacheLinux_05"
+#define CACHE_FILE_MAGIC "RMGCoreHeaderAndSettingsCacheLinux_06"
 #endif // _WIN32
 #define CACHE_FILE_ITEMS_MAX 10000
 
@@ -103,6 +105,8 @@ void CoreReadRomHeaderAndSettingsCache(void)
     char magicBuf[sizeof(CACHE_FILE_MAGIC)];
     wchar_t fileNameBuf[MAX_FILENAME_LEN];
     char headerNameBuf[ROMHEADER_NAME_LEN];
+    char gameIDBuf[GAMEID_LEN];
+    char regionBuf[REGION_LEN];
     char goodNameBuf[GOODNAME_LEN];
     char md5Buf[MD5_LEN];
     uint32_t size;
@@ -131,6 +135,8 @@ void CoreReadRomHeaderAndSettingsCache(void)
         size = 0;
         memset(fileNameBuf, 0, sizeof(fileNameBuf));
         memset(headerNameBuf, 0, sizeof(headerNameBuf));
+        memset(gameIDBuf, 0, sizeof(gameIDBuf));
+        memset(regionBuf, 0, sizeof(regionBuf));
         memset(goodNameBuf, 0, sizeof(goodNameBuf));
         memset(md5Buf, 0, sizeof(md5Buf));
 
@@ -144,7 +150,13 @@ void CoreReadRomHeaderAndSettingsCache(void)
         // header
         FREAD(size);
         FREAD_STR(headerNameBuf, size);
+        FREAD(size);
+        FREAD_STR(gameIDBuf, size);
+        FREAD(size);
+        FREAD_STR(regionBuf, size);
         cacheEntry.header.Name = std::string(headerNameBuf);
+        cacheEntry.header.GameID = std::string(gameIDBuf);
+        cacheEntry.header.Region = std::string(regionBuf);
         FREAD(cacheEntry.header.CRC1);
         FREAD(cacheEntry.header.CRC2);
         // (partial) settings
@@ -169,6 +181,8 @@ bool CoreSaveRomHeaderAndSettingsCache(void)
     std::ofstream outputStream;
     wchar_t fileNameBuf[MAX_FILENAME_LEN];
     char headerNameBuf[ROMHEADER_NAME_LEN];
+    char gameIDBuf[GAMEID_LEN];
+    char regionBuf[REGION_LEN];
     char goodNameBuf[GOODNAME_LEN];
     char md5Buf[MD5_LEN];
     uint32_t size;
@@ -200,12 +214,16 @@ bool CoreSaveRomHeaderAndSettingsCache(void)
         size = 0;
         memset(fileNameBuf, 0, sizeof(fileNameBuf));
         memset(headerNameBuf, 0, sizeof(headerNameBuf));
+        memset(gameIDBuf, 0, sizeof(gameIDBuf));
+        memset(regionBuf, 0, sizeof(regionBuf));
         memset(goodNameBuf, 0, sizeof(goodNameBuf));
         memset(md5Buf, 0, sizeof(md5Buf));
 
         // copy strings into buffers
         wcsncpy(fileNameBuf, cacheEntry.fileName.wstring().c_str(), MAX_FILENAME_LEN);
         strncpy(headerNameBuf, cacheEntry.header.Name.c_str(), sizeof(headerNameBuf));
+        strncpy(gameIDBuf, cacheEntry.header.GameID.c_str(), sizeof(gameIDBuf));
+        strncpy(regionBuf, cacheEntry.header.Region.c_str(), sizeof(regionBuf));
         strncpy(goodNameBuf, cacheEntry.settings.GoodName.c_str(), sizeof(goodNameBuf));
         strncpy(md5Buf, cacheEntry.settings.MD5.c_str(), sizeof(md5Buf));
 
@@ -220,6 +238,12 @@ bool CoreSaveRomHeaderAndSettingsCache(void)
         size = cacheEntry.header.Name.size();
         FWRITE(size);
         FWRITE_STR(headerNameBuf, size);
+        size = cacheEntry.header.GameID.size();
+        FWRITE(size);
+        FWRITE_STR(gameIDBuf, size);
+        size = cacheEntry.header.Region.size();
+        FWRITE(size);
+        FWRITE_STR(regionBuf, size);
         FWRITE(cacheEntry.header.CRC1);
         FWRITE(cacheEntry.header.CRC2);
         // (partial) settings

--- a/Source/RMG-Core/RomHeader.cpp
+++ b/Source/RMG-Core/RomHeader.cpp
@@ -25,7 +25,7 @@
 // Local Functions
 //
 
-static std::string generateGameID(m64p_rom_header header)
+static std::string generate_game_id(m64p_rom_header header)
 {
     std::string gameID;
 
@@ -42,7 +42,7 @@ static std::string generateGameID(m64p_rom_header header)
     return gameID;
 }
 
-static std::string generateRegionString(char countryCode)
+static std::string generate_region_string(char countryCode)
 {
     std::string region;
 
@@ -140,8 +140,8 @@ bool CoreGetCurrentRomHeader(CoreRomHeader& header)
     header.CRC2        = ntohl(m64p_header.CRC2);
     header.CountryCode = m64p_header.Country_code;
     header.Name        = CoreConvertStringEncoding((char*)m64p_header.Name, CoreStringEncoding::Shift_JIS);
-    header.GameID      = generateGameID(m64p_header);
-    header.Region      = generateRegionString((char)header.CountryCode);
+    header.GameID      = generate_game_id(m64p_header);
+    header.Region      = generate_region_string((char)header.CountryCode);
 
     return true;
 }

--- a/Source/RMG-Core/RomHeader.cpp
+++ b/Source/RMG-Core/RomHeader.cpp
@@ -68,6 +68,16 @@ bool CoreGetCurrentRomHeader(CoreRomHeader& header)
         header.Region = "Japan/North America";
         break;
 
+        case 66:
+        // B
+        header.Region = "Brazil";
+        break;
+
+        case 67:
+        // C
+        header.Region = "China";
+        break;
+
         case 68:
         // D
         header.Region = "Germany";
@@ -83,6 +93,16 @@ bool CoreGetCurrentRomHeader(CoreRomHeader& header)
         header.Region = "France";
         break;
 
+        case 71:
+        // G
+        header.Region = "Gateway 64 (NTSC)";
+        break;
+
+        case 72:
+        // H
+        header.Region = "Netherlands";
+        break;
+
         case 73:
         // I
         header.Region = "Italy";
@@ -91,6 +111,21 @@ bool CoreGetCurrentRomHeader(CoreRomHeader& header)
         case 74:
         // J
         header.Region = "Japan";
+        break;
+
+        case 75:
+        // K
+        header.Region = "Korea";
+        break;
+
+        case 76:
+        // L
+        header.Region = "Gateway 64 (PAL)";
+        break;
+
+        case 78:
+        // N
+        header.Region = "Canada";
         break;
 
         case 80:
@@ -108,9 +143,19 @@ bool CoreGetCurrentRomHeader(CoreRomHeader& header)
         header.Region = "Australia";
         break;
 
+        case 87:
+        // W
+        header.Region = "Scandanavia";
+        break;
+
         case 88:
         // X
-        header.Region = "U.K./Australia";
+        header.Region = "Europe/Australia";
+        break;
+
+        case 89:
+        // Y
+        header.Region = "Europe";
         break;
 
         default:

--- a/Source/RMG-Core/RomHeader.cpp
+++ b/Source/RMG-Core/RomHeader.cpp
@@ -65,7 +65,7 @@ bool CoreGetCurrentRomHeader(CoreRomHeader& header)
     {
         case 65:
         // A
-        header.Region = "Japan/North America";
+        header.Region = "Region-Free";
         break;
 
         case 66:
@@ -155,6 +155,11 @@ bool CoreGetCurrentRomHeader(CoreRomHeader& header)
 
         case 89:
         // Y
+        header.Region = "Europe";
+        break;
+
+        case 90:
+        // Z
         header.Region = "Europe";
         break;
 

--- a/Source/RMG-Core/RomHeader.cpp
+++ b/Source/RMG-Core/RomHeader.cpp
@@ -49,6 +49,74 @@ bool CoreGetCurrentRomHeader(CoreRomHeader& header)
     header.CRC2        = ntohl(m64p_header.CRC2);
     header.CountryCode = m64p_header.Country_code;
     header.Name        = CoreConvertStringEncoding((char*)m64p_header.Name, CoreStringEncoding::Shift_JIS);
+
+    header.GameID.clear();
+    header.GameID.push_back(char(ntohl(m64p_header.Manufacturer_ID)));
+    header.GameID.push_back(char(m64p_header.Cartridge_ID % 256));
+    header.GameID.push_back(char(m64p_header.Cartridge_ID / 256));
+    header.GameID.push_back(char(header.CountryCode));
+
+    if (header.GameID[0] == '\0')
+    {
+        header.GameID = "????";
+    }
     
+    switch (header.CountryCode)
+    {
+        case 65:
+        // A
+        header.Region = "Japan/North America";
+        break;
+
+        case 68:
+        // D
+        header.Region = "Germany";
+        break;
+
+        case 69:
+        // E
+        header.Region = "North America";
+        break;
+
+        case 70:
+        // F
+        header.Region = "France";
+        break;
+
+        case 73:
+        // I
+        header.Region = "Italy";
+        break;
+
+        case 74:
+        // J
+        header.Region = "Japan";
+        break;
+
+        case 80:
+        // P
+        header.Region = "Europe/Australia";
+        break;
+
+        case 83:
+        // S
+        header.Region = "Spain";
+        break;
+
+        case 85:
+        // U
+        header.Region = "Australia";
+        break;
+
+        case 88:
+        // X
+        header.Region = "U.K./Australia";
+        break;
+
+        default:
+        header.Region = "Unknown";
+        break;
+    }
+
     return true;
 }

--- a/Source/RMG-Core/RomHeader.cpp
+++ b/Source/RMG-Core/RomHeader.cpp
@@ -25,7 +25,7 @@
 // Local Functions
 //
 
-static std::string generate_game_id(m64p_rom_header header)
+static std::string get_gameid_from_header(m64p_rom_header header)
 {
     std::string gameID;
 
@@ -42,7 +42,7 @@ static std::string generate_game_id(m64p_rom_header header)
     return gameID;
 }
 
-static std::string generate_region_string(char countryCode)
+static std::string get_region_from_countrycode(char countryCode)
 {
     std::string region;
 
@@ -140,8 +140,8 @@ bool CoreGetCurrentRomHeader(CoreRomHeader& header)
     header.CRC2        = ntohl(m64p_header.CRC2);
     header.CountryCode = m64p_header.Country_code;
     header.Name        = CoreConvertStringEncoding((char*)m64p_header.Name, CoreStringEncoding::Shift_JIS);
-    header.GameID      = generate_game_id(m64p_header);
-    header.Region      = generate_region_string((char)header.CountryCode);
+    header.GameID      = get_gameid_from_header(m64p_header);
+    header.Region      = get_region_from_countrycode((char)header.CountryCode);
 
     return true;
 }

--- a/Source/RMG-Core/RomHeader.cpp
+++ b/Source/RMG-Core/RomHeader.cpp
@@ -22,6 +22,97 @@
 #include "Rom.hpp"
 
 //
+// Local Functions
+//
+
+static std::string generateGameID(m64p_rom_header header)
+{
+    std::string gameID;
+
+    if (header.Manufacturer_ID == 0)
+    {
+        return "????";
+    }
+
+    gameID.push_back(char(ntohl(header.Manufacturer_ID)));
+    gameID.push_back(char(header.Cartridge_ID % 256));
+    gameID.push_back(char(header.Cartridge_ID / 256));
+    gameID.push_back(char(header.Country_code));
+
+    return gameID;
+}
+
+static std::string generateRegionString(char countryCode)
+{
+    std::string region;
+
+    switch (countryCode)
+    {
+        case 'A':
+            region = "Region-Free";
+            break;
+        case 'B':
+            region = "Brazil";
+            break;
+        case 'C':
+            region = "China";
+            break;
+        case 'D':
+            region = "Germany";
+            break;
+        case 'E':
+            region = "North America";
+            break;
+        case 'F':
+            region = "France";
+            break;
+        case 'G':
+            region = "Gateway 64 (NTSC)";
+            break;
+        case 'H':
+            region = "Netherlands";
+            break;
+        case 'I':
+            region = "Italy";
+            break;
+        case 'J':
+            region = "Japan";
+            break;
+        case 'K':
+            region = "Korea";
+            break;
+        case 'L':
+            region = "Gateway 64 (PAL)";
+            break;
+        case 'N':
+            region = "Canada";
+            break;
+        case 'P':
+        case 'X':
+            region = "Europe/Australia";
+            break;
+        case 'S':
+            region = "Spain";
+            break;
+        case 'U':
+            region = "Australia";
+            break;
+        case 'W':
+            region = "Scandanavia";
+            break;
+        case 'Y':
+        case 'Z':
+            region = "Europe";
+            break;
+        default:
+            region = "Unknown";
+            break;
+    }
+
+    return region;
+}
+
+//
 // Exported Functions
 //
 
@@ -49,124 +140,8 @@ bool CoreGetCurrentRomHeader(CoreRomHeader& header)
     header.CRC2        = ntohl(m64p_header.CRC2);
     header.CountryCode = m64p_header.Country_code;
     header.Name        = CoreConvertStringEncoding((char*)m64p_header.Name, CoreStringEncoding::Shift_JIS);
-
-    header.GameID.clear();
-    header.GameID.push_back(char(ntohl(m64p_header.Manufacturer_ID)));
-    header.GameID.push_back(char(m64p_header.Cartridge_ID % 256));
-    header.GameID.push_back(char(m64p_header.Cartridge_ID / 256));
-    header.GameID.push_back(char(header.CountryCode));
-
-    if (header.GameID[0] == '\0')
-    {
-        header.GameID = "????";
-    }
-    
-    switch (header.CountryCode)
-    {
-        case 65:
-        // A
-        header.Region = "Region-Free";
-        break;
-
-        case 66:
-        // B
-        header.Region = "Brazil";
-        break;
-
-        case 67:
-        // C
-        header.Region = "China";
-        break;
-
-        case 68:
-        // D
-        header.Region = "Germany";
-        break;
-
-        case 69:
-        // E
-        header.Region = "North America";
-        break;
-
-        case 70:
-        // F
-        header.Region = "France";
-        break;
-
-        case 71:
-        // G
-        header.Region = "Gateway 64 (NTSC)";
-        break;
-
-        case 72:
-        // H
-        header.Region = "Netherlands";
-        break;
-
-        case 73:
-        // I
-        header.Region = "Italy";
-        break;
-
-        case 74:
-        // J
-        header.Region = "Japan";
-        break;
-
-        case 75:
-        // K
-        header.Region = "Korea";
-        break;
-
-        case 76:
-        // L
-        header.Region = "Gateway 64 (PAL)";
-        break;
-
-        case 78:
-        // N
-        header.Region = "Canada";
-        break;
-
-        case 80:
-        // P
-        header.Region = "Europe/Australia";
-        break;
-
-        case 83:
-        // S
-        header.Region = "Spain";
-        break;
-
-        case 85:
-        // U
-        header.Region = "Australia";
-        break;
-
-        case 87:
-        // W
-        header.Region = "Scandanavia";
-        break;
-
-        case 88:
-        // X
-        header.Region = "Europe/Australia";
-        break;
-
-        case 89:
-        // Y
-        header.Region = "Europe";
-        break;
-
-        case 90:
-        // Z
-        header.Region = "Europe";
-        break;
-
-        default:
-        header.Region = "Unknown";
-        break;
-    }
+    header.GameID      = generateGameID(m64p_header);
+    header.Region      = generateRegionString((char)header.CountryCode);
 
     return true;
 }

--- a/Source/RMG-Core/RomHeader.hpp
+++ b/Source/RMG-Core/RomHeader.hpp
@@ -19,6 +19,8 @@ struct CoreRomHeader
     uint32_t    CRC2;
     uint32_t    CountryCode;
     std::string Name;
+    std::string GameID;
+    std::string Region;
 };
 
 // retrieves the currently opened ROM header

--- a/Source/RMG-Core/Settings/Settings.cpp
+++ b/Source/RMG-Core/Settings/Settings.cpp
@@ -545,13 +545,13 @@ static l_Setting get_setting(SettingsID settingId)
         setting = {SETTING_SECTION_ROMBROWSER, "MaxItems", 250};
         break;
     case SettingsID::RomBrowser_ColumnVisibility:
-        setting = {SETTING_SECTION_ROMBROWSER, "ColumnVisibility", std::vector<int>({1, 1, 1})};
+        setting = {SETTING_SECTION_ROMBROWSER, "ColumnVisibility", std::vector<int>({1, 1, 1, 0, 0, 0, 0, 0, 0})};
         break;
     case SettingsID::RomBrowser_ColumnOrder:
-        setting = {SETTING_SECTION_ROMBROWSER, "ColumnOrder", std::vector<int>({0, 1, 2})};
+        setting = {SETTING_SECTION_ROMBROWSER, "ColumnOrder", std::vector<int>({0, 1, 2, 3, 4, 5, 6, 7, 8})};
         break;
     case SettingsID::RomBrowser_ColumnSizes:
-        setting = {SETTING_SECTION_ROMBROWSER, "ColumnSizes", std::vector<int>({-1, -1, -1})};
+        setting = {SETTING_SECTION_ROMBROWSER, "ColumnSizes", std::vector<int>({-1, -1, -1, -1, -1, -1, -1, -1, -1})};
         break;
     case SettingsID::RomBrowser_SortAfterSearch:
         setting = {SETTING_SECTION_ROMBROWSER, "SortAfterSearch", true};

--- a/Source/RMG/UserInterface/Dialog/RomInfoDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/RomInfoDialog.cpp
@@ -30,7 +30,8 @@ RomInfoDialog::RomInfoDialog(QString file, CoreRomHeader romHeader, CoreRomSetti
     this->locationLineEdit->setCursorPosition(0);
     this->crc1LineEdit->setText(QString::number(romHeader.CRC1, 16).toUpper());
     this->crc2LineEdit->setText(QString::number(romHeader.CRC2, 16).toUpper());
-    this->countryCodeLineEdit->setText(QString((char)romHeader.CountryCode));
+    this->gameIDLineEdit->setText(QString::fromStdString(romHeader.GameID));
+    this->gameRegionLineEdit->setText(QString::fromStdString(romHeader.Region));
 }
 
 RomInfoDialog::~RomInfoDialog(void)

--- a/Source/RMG/UserInterface/Dialog/RomInfoDialog.ui
+++ b/Source/RMG/UserInterface/Dialog/RomInfoDialog.ui
@@ -199,12 +199,36 @@
         <item>
          <widget class="QLabel" name="label_7">
           <property name="text">
-           <string>Country Code</string>
+           <string>Game I.D.</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="countryCodeLineEdit">
+         <widget class="QLineEdit" name="gameIDLineEdit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_8">
+        <item>
+         <widget class="QLabel" name="label_8">
+          <property name="text">
+           <string>Game Region</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="gameRegionLineEdit">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
             <horstretch>0</horstretch>

--- a/Source/RMG/UserInterface/Widget/RomBrowserWidget.cpp
+++ b/Source/RMG/UserInterface/Widget/RomBrowserWidget.cpp
@@ -113,7 +113,7 @@ RomBrowserWidget::RomBrowserWidget(QWidget *parent) : QStackedWidget(parent)
     labels << "Format";
     labels << "File Name";
     labels << "File Ext.";
-    labels << "Size";
+    labels << "File Size";
     labels << "I.D.";
     labels << "Region";
     this->listViewModel->setColumnCount(labels.size());
@@ -126,7 +126,7 @@ RomBrowserWidget::RomBrowserWidget(QWidget *parent) : QStackedWidget(parent)
     this->columnNames << "Game Format";
     this->columnNames << labels.at(4);
     this->columnNames << "File Extension";
-    this->columnNames << "File Size";
+    this->columnNames << labels.at(6);
     this->columnNames << "Game I.D.";
     this->columnNames << "Game Region";
 
@@ -638,7 +638,8 @@ void RomBrowserWidget::on_RomBrowserThread_RomFound(QString file, CoreRomType ty
 {
     QString name;
     QString gameFormat;
-    QString fileSize;
+    float fileSize;
+    QString fileSizeString;
     QString coverFile;
     QIcon   coverIcon;
     QVariant itemData;
@@ -666,10 +667,11 @@ void RomBrowserWidget::on_RomBrowserThread_RomFound(QString file, CoreRomType ty
     }
 
     // generate file size to use in UI
-    fileSize = (QString::number(QFileInfo(file).size()/1048576)).append(" MB");
-    if (fileSize.size() == 4)
+    fileSize = QFileInfo(file).size()/1048576.0;
+    fileSizeString = (QString::number(fileSize, 'f', 2)).append(" MB");
+    if (fileSizeString.size() == 7)
     {
-        fileSize = fileSize.prepend("  ");
+        fileSizeString = fileSizeString.prepend("  ");
     }
 
     // retrieve cover image
@@ -712,7 +714,7 @@ void RomBrowserWidget::on_RomBrowserThread_RomFound(QString file, CoreRomType ty
     listViewRow.append(listViewItem6);
     // file size
     QStandardItem* listViewItem7 = new QStandardItem();
-    listViewItem7->setText(fileSize);
+    listViewItem7->setText(fileSizeString);
     listViewItem7->setData(itemData);
     listViewRow.append(listViewItem7);
     // game i.d.

--- a/Source/RMG/UserInterface/Widget/RomBrowserWidget.cpp
+++ b/Source/RMG/UserInterface/Widget/RomBrowserWidget.cpp
@@ -105,13 +105,30 @@ RomBrowserWidget::RomBrowserWidget(QWidget *parent) : QStackedWidget(parent)
     connect(this->listViewWidget, &Widget::RomBrowserListViewWidget::ZoomIn, this, &RomBrowserWidget::on_ZoomIn);
     connect(this->listViewWidget, &Widget::RomBrowserListViewWidget::ZoomOut, this, &RomBrowserWidget::on_ZoomOut);
 
-    // TODO
+    // set up list view's columns
     QStringList labels;
     labels << "Name";
     labels << "Internal Name";
     labels << "MD5";
+    labels << "Format";
+    labels << "File Name";
+    labels << "File Ext.";
+    labels << "Size";
+    labels << "I.D.";
+    labels << "Region";
     this->listViewModel->setColumnCount(labels.size());
     this->listViewModel->setHorizontalHeaderLabels(labels);
+
+    // set full names of list view's columns
+    this->columnNames << labels.at(0);
+    this->columnNames << labels.at(1);
+    this->columnNames << labels.at(2);
+    this->columnNames << "Game Format";
+    this->columnNames << labels.at(4);
+    this->columnNames << "File Extension";
+    this->columnNames << "File Size";
+    this->columnNames << "Game I.D.";
+    this->columnNames << "Game Region";
 
     // configure grid view widget
     this->gridViewWidget = new Widget::RomBrowserGridViewWidget(this);
@@ -152,6 +169,7 @@ RomBrowserWidget::RomBrowserWidget(QWidget *parent) : QStackedWidget(parent)
     this->action_RomInformation = new QAction(this);
     this->action_EditGameSettings = new QAction(this);
     this->action_EditCheats = new QAction(this);
+    this->action_ResetColumnSizes = new QAction(this);
     this->action_SetCoverImage = new QAction(this);
     this->action_RemoveCoverImage = new QAction(this);
 
@@ -168,9 +186,10 @@ RomBrowserWidget::RomBrowserWidget(QWidget *parent) : QStackedWidget(parent)
     this->action_RomInformation->setText("ROM Information");
     this->action_EditGameSettings->setText("Edit Game Settings");
     this->action_EditCheats->setText("Edit Cheats");
+    this->action_ResetColumnSizes->setText("Reset Column Sizes");
+    this->menu_Columns->menuAction()->setText("Show/Hide Columns");
     this->action_SetCoverImage->setText("Set Cover Image...");
     this->action_RemoveCoverImage->setText("Remove Cover Image");
-    this->menu_Columns->menuAction()->setText("Show/Hide Columns");
     connect(this->action_PlayGame, &QAction::triggered, this, &RomBrowserWidget::on_Action_PlayGame);
     connect(this->action_PlayGameWith, &QAction::triggered, this, &RomBrowserWidget::on_Action_PlayGameWith);
     connect(this->action_RefreshRomList, &QAction::triggered, this, &RomBrowserWidget::on_Action_RefreshRomList);
@@ -179,6 +198,7 @@ RomBrowserWidget::RomBrowserWidget(QWidget *parent) : QStackedWidget(parent)
     connect(this->action_RomInformation, &QAction::triggered, this, &RomBrowserWidget::on_Action_RomInformation);
     connect(this->action_EditGameSettings, &QAction::triggered, this, &RomBrowserWidget::on_Action_EditGameSettings);
     connect(this->action_EditCheats, &QAction::triggered, this, &RomBrowserWidget::on_Action_EditCheats);
+    connect(this->action_ResetColumnSizes, &QAction::triggered, this, &RomBrowserWidget::on_Action_ResetColumnSizes);
     connect(this->action_SetCoverImage, &QAction::triggered, this, &RomBrowserWidget::on_Action_SetCoverImage);
     connect(this->action_RemoveCoverImage, &QAction::triggered, this, &RomBrowserWidget::on_Action_RemoveCoverImage);
 
@@ -196,9 +216,10 @@ RomBrowserWidget::RomBrowserWidget(QWidget *parent) : QStackedWidget(parent)
     this->contextMenu->addAction(this->action_EditGameSettings);
     this->contextMenu->addAction(this->action_EditCheats);
     this->contextMenu->addSeparator();
+    this->contextMenu->addAction(this->action_ResetColumnSizes);
+    this->contextMenu->addMenu(this->menu_Columns);
     this->contextMenu->addAction(this->action_SetCoverImage);
     this->contextMenu->addAction(this->action_RemoveCoverImage);
-    this->contextMenu->addMenu(this->menu_Columns);
 
     // configure current view widget
     int currentView = CoreSettingsGetIntValue(SettingsID::RomBrowser_ViewMode);
@@ -465,11 +486,12 @@ void RomBrowserWidget::customContextMenuRequested(QPoint position)
     this->action_RomInformation->setEnabled(hasSelection);
     this->action_EditGameSettings->setEnabled(hasSelection);
     this->action_EditCheats->setEnabled(hasSelection);
+    this->action_ResetColumnSizes->setVisible(view == this->listViewWidget);
+    this->menu_Columns->menuAction()->setVisible(view == this->listViewWidget);
     this->action_SetCoverImage->setEnabled(hasSelection);
     this->action_SetCoverImage->setVisible(view == this->gridViewWidget);
     this->action_RemoveCoverImage->setEnabled(hasSelection && !data.coverFile.isEmpty());
     this->action_RemoveCoverImage->setVisible(view == this->gridViewWidget);
-    this->menu_Columns->menuAction()->setVisible(view == this->listViewWidget);
 
     if (hasSelection && data.type == CoreRomType::Disk)
     { // disk selected
@@ -478,6 +500,11 @@ void RomBrowserWidget::customContextMenuRequested(QPoint position)
     else
     { // cartridge selected
         this->action_PlayGameWith->setText("Play Game with Disk");
+    }
+
+    if (view == this->listViewWidget)
+    { // list view
+        this->generateColumnsMenu();
     }
 
     if (view == this->gridViewWidget)
@@ -492,11 +519,6 @@ void RomBrowserWidget::customContextMenuRequested(QPoint position)
         }
     }
 
-    if (view == this->listViewWidget)
-    { // list view
-        this->generateColumnsMenu();
-    }
-
     this->contextMenu->popup(this->mapToGlobal(position));
 }
 
@@ -508,7 +530,7 @@ void RomBrowserWidget::generateColumnsMenu(void)
     {
         int column = this->listViewWidget->horizontalHeader()->logicalIndex(i);
 
-        this->action_ColumnsMenuEntry = menu_Columns->addAction(this->listViewModel->horizontalHeaderItem(column)->text());
+        this->action_ColumnsMenuEntry = menu_Columns->addAction(this->columnNames.at(column));
         this->action_ColumnsMenuEntry->setCheckable(true);
         this->action_ColumnsMenuEntry->setChecked(!this->listViewWidget->horizontalHeader()->isSectionHidden(column));
         connect(this->action_ColumnsMenuEntry, &QAction::toggled, [this, column](bool checked)
@@ -526,33 +548,42 @@ void RomBrowserWidget::on_listViewWidget_sortIndicatorChanged(int logicalIndex, 
 
 void RomBrowserWidget::on_listViewWidget_sectionResized(int logicalIndex, int oldWidth, int newWidth)
 {
-    std::vector<int> columnVisibility = CoreSettingsGetIntListValue(SettingsID::RomBrowser_ColumnVisibility);
     std::vector<int> columnSizes = CoreSettingsGetIntListValue(SettingsID::RomBrowser_ColumnSizes);
 
-    if (newWidth == 0)
+    if (!this->listViewWidget->horizontalHeader()->stretchLastSection())
     {
-        columnVisibility.at(logicalIndex) = 0;
-        CoreSettingsSetValue(SettingsID::RomBrowser_ColumnVisibility, columnVisibility);
+        columnSizes.at(logicalIndex) = newWidth;
+        CoreSettingsSetValue(SettingsID::RomBrowser_ColumnSizes, columnSizes);
     }
     else
     {
-        columnVisibility.at(logicalIndex) = 1;
-        CoreSettingsSetValue(SettingsID::RomBrowser_ColumnVisibility, columnVisibility);
+        std::vector<int> columnVisibility = CoreSettingsGetIntListValue(SettingsID::RomBrowser_ColumnVisibility);
 
-        int lastVisibleColumn = -1;
-        for (int i = 0; i < this->listViewModel->columnCount(); i++)
+        if (newWidth == 0)
         {
-            int column = this->listViewWidget->horizontalHeader()->logicalIndex(i);
-            if (!this->listViewWidget->horizontalHeader()->isSectionHidden(column))
-            {
-                lastVisibleColumn = column;
-            }
+            columnVisibility.at(logicalIndex) = 0;
+            CoreSettingsSetValue(SettingsID::RomBrowser_ColumnVisibility, columnVisibility);
         }
-
-        if (!this->listViewWidget->horizontalHeader()->stretchLastSection() || logicalIndex != lastVisibleColumn)
+        else
         {
-            columnSizes.at(logicalIndex) = newWidth;
-            CoreSettingsSetValue(SettingsID::RomBrowser_ColumnSizes, columnSizes);
+            columnVisibility.at(logicalIndex) = 1;
+            CoreSettingsSetValue(SettingsID::RomBrowser_ColumnVisibility, columnVisibility);
+
+            int lastVisibleColumn = -1;
+            for (int i = 0; i < this->listViewModel->columnCount(); i++)
+            {
+                int column = this->listViewWidget->horizontalHeader()->logicalIndex(i);
+                if (!this->listViewWidget->horizontalHeader()->isSectionHidden(column))
+                {
+                    lastVisibleColumn = column;
+                }
+            }
+
+            if (logicalIndex != lastVisibleColumn)
+            {
+                columnSizes.at(logicalIndex) = newWidth;
+                CoreSettingsSetValue(SettingsID::RomBrowser_ColumnSizes, columnSizes);
+            }
         }
     }
 }
@@ -606,6 +637,8 @@ void RomBrowserWidget::on_ZoomOut(void)
 void RomBrowserWidget::on_RomBrowserThread_RomFound(QString file, CoreRomType type, CoreRomHeader header, CoreRomSettings settings)
 {
     QString name;
+    QString gameFormat;
+    QString fileSize;
     QString coverFile;
     QIcon   coverIcon;
     QVariant itemData;
@@ -620,6 +653,23 @@ void RomBrowserWidget::on_RomBrowserThread_RomFound(QString file, CoreRomType ty
         name.endsWith("(unknown disk)"))
     {
         name = QFileInfo(file).fileName();
+    }
+
+    // generate game format to use in UI
+    if (type == CoreRomType::Disk)
+    {
+        gameFormat = "Disk";
+    }
+    else
+    {
+        gameFormat = "Cartridge";
+    }
+
+    // generate file size to use in UI
+    fileSize = (QString::number(QFileInfo(file).size()/1048576)).append(" MB");
+    if (fileSize.size() == 4)
+    {
+        fileSize = fileSize.prepend("  ");
     }
 
     // retrieve cover image
@@ -645,6 +695,36 @@ void RomBrowserWidget::on_RomBrowserThread_RomFound(QString file, CoreRomType ty
     listViewItem3->setText(QString::fromStdString(settings.MD5));
     listViewItem3->setData(itemData);
     listViewRow.append(listViewItem3);
+    // game format
+    QStandardItem* listViewItem4 = new QStandardItem();
+    listViewItem4->setText(gameFormat);
+    listViewItem4->setData(itemData);
+    listViewRow.append(listViewItem4);
+    // file name
+    QStandardItem* listViewItem5 = new QStandardItem();
+    listViewItem5->setText(QFileInfo(file).completeBaseName());
+    listViewItem5->setData(itemData);
+    listViewRow.append(listViewItem5);
+    // file extension
+    QStandardItem* listViewItem6 = new QStandardItem();
+    listViewItem6->setText(((QFileInfo(file).suffix()).prepend(".")).toUpper());
+    listViewItem6->setData(itemData);
+    listViewRow.append(listViewItem6);
+    // file size
+    QStandardItem* listViewItem7 = new QStandardItem();
+    listViewItem7->setText(fileSize);
+    listViewItem7->setData(itemData);
+    listViewRow.append(listViewItem7);
+    // game i.d.
+    QStandardItem* listViewItem8 = new QStandardItem();
+    listViewItem8->setText(QString::fromStdString(header.GameID));
+    listViewItem8->setData(itemData);
+    listViewRow.append(listViewItem8);
+    // region
+    QStandardItem* listViewItem9 = new QStandardItem();
+    listViewItem9->setText(QString::fromStdString(header.Region));
+    listViewItem9->setData(itemData);
+    listViewRow.append(listViewItem9);
     this->listViewModel->appendRow(listViewRow);
 
     QStandardItem* gridViewItem = new QStandardItem();
@@ -664,33 +744,12 @@ void RomBrowserWidget::on_RomBrowserThread_Finished(bool canceled)
     }
 
     // retrieve column settings
-    std::vector<int> columnVisibility = CoreSettingsGetIntListValue(SettingsID::RomBrowser_ColumnVisibility);
-    std::vector<int> columnOrder = CoreSettingsGetIntListValue(SettingsID::RomBrowser_ColumnOrder);
     std::vector<int> columnSizes = CoreSettingsGetIntListValue(SettingsID::RomBrowser_ColumnSizes);
+    std::vector<int> columnOrder = CoreSettingsGetIntListValue(SettingsID::RomBrowser_ColumnOrder);
+    std::vector<int> columnVisibility = CoreSettingsGetIntListValue(SettingsID::RomBrowser_ColumnVisibility);
 
     // temporarily disable stretching last column in list view
     this->listViewWidget->horizontalHeader()->setStretchLastSection(false);
-
-    // reset column visibility setting in config file if number of values is incorrect
-    if (!columnVisibility.empty() &&
-        columnVisibility.size() != this->listViewModel->columnCount())
-    {
-        columnVisibility.clear();
-        columnVisibility.resize(this->listViewModel->columnCount(), 1);
-        CoreSettingsSetValue(SettingsID::RomBrowser_ColumnVisibility, columnVisibility);
-    }
-
-    // reset column order setting in config file if number of values is incorrect
-    if (!columnOrder.empty() &&
-        columnOrder.size() != this->listViewModel->columnCount())
-    {
-        columnOrder.clear();
-        for (int i = 0; i < this->listViewModel->columnCount(); i++)
-        {
-            columnOrder.push_back(i);
-        }
-        CoreSettingsSetValue(SettingsID::RomBrowser_ColumnOrder, columnOrder);
-    }
 
     // reset column sizes setting in config file if number of values is incorrect
     if (!columnSizes.empty() && 
@@ -699,21 +758,6 @@ void RomBrowserWidget::on_RomBrowserThread_Finished(bool canceled)
         columnSizes.clear();
         columnSizes.resize(this->listViewModel->columnCount(), -1);
         CoreSettingsSetValue(SettingsID::RomBrowser_ColumnSizes, columnSizes);
-    }
-
-    // update list view's column visibilities
-    for (int i = 0; i < columnVisibility.size(); i++)
-    {
-        if (columnVisibility.at(i) == 0)
-        {
-            this->listViewWidget->horizontalHeader()->setSectionHidden(i, true);
-        }
-    }
-
-    // update list view's column order
-    for (int i = 0; i < columnOrder.size(); i++)
-    {
-        this->listViewWidget->horizontalHeader()->moveSection(this->listViewWidget->horizontalHeader()->visualIndex(i), columnOrder.at(i));
     }
 
     // update list view's column sizes
@@ -732,6 +776,46 @@ void RomBrowserWidget::on_RomBrowserThread_Finished(bool canceled)
 
     // enable stretching last column in list view
     this->listViewWidget->horizontalHeader()->setStretchLastSection(true);
+
+    // reset column order setting in config file if number of values is incorrect
+    if (!columnOrder.empty() &&
+        columnOrder.size() != this->listViewModel->columnCount())
+    {
+        columnOrder.clear();
+        for (int i = 0; i < this->listViewModel->columnCount(); i++)
+        {
+            columnOrder.push_back(i);
+        }
+        CoreSettingsSetValue(SettingsID::RomBrowser_ColumnOrder, columnOrder);
+    }
+
+    // update list view's column order
+    for (int i = 0; i < columnOrder.size(); i++)
+    {
+        this->listViewWidget->horizontalHeader()->moveSection(this->listViewWidget->horizontalHeader()->visualIndex(i), columnOrder.at(i));
+    }
+
+    // reset column visibility setting in config file if number of values is incorrect
+    if (!columnVisibility.empty() &&
+        columnVisibility.size() != this->listViewModel->columnCount())
+    {
+        columnVisibility.clear();
+        columnVisibility.resize(this->listViewModel->columnCount(), 0);
+        for (int i = 0; i < 3; i++)
+        {
+            columnVisibility.at(i) = 1;
+        }
+        CoreSettingsSetValue(SettingsID::RomBrowser_ColumnVisibility, columnVisibility);
+    }
+
+    // update list view's column visibilities
+    for (int i = 0; i < columnVisibility.size(); i++)
+    {
+        if (columnVisibility.at(i) == 0)
+        {
+            this->listViewWidget->horizontalHeader()->setSectionHidden(i, true);
+        }
+    }
 
     if (!canceled)
     {
@@ -806,6 +890,28 @@ void RomBrowserWidget::on_Action_EditGameSettings(void)
 void RomBrowserWidget::on_Action_EditCheats(void)
 {
     emit this->Cheats(this->getCurrentRom());
+}
+
+void RomBrowserWidget::on_Action_ResetColumnSizes(void)
+{
+    std::vector<int> columnVisibility = CoreSettingsGetIntListValue(SettingsID::RomBrowser_ColumnVisibility);
+    this->listViewWidget->horizontalHeader()->setStretchLastSection(false);
+
+    for (int i = 0; i < this->listViewModel->columnCount(); i++)
+    {
+        this->listViewWidget->horizontalHeader()->setSectionHidden(i, false);
+    }
+
+    this->listViewWidget->resizeColumnsToContents();
+    this->listViewWidget->horizontalHeader()->setStretchLastSection(true);
+
+    for (int i = 0; i < columnVisibility.size(); i++)
+    {
+        if (columnVisibility.at(i) == 0)
+        {
+            this->listViewWidget->horizontalHeader()->setSectionHidden(i, true);
+        }
+    }
 }
 
 void RomBrowserWidget::on_Action_SetCoverImage(void)

--- a/Source/RMG/UserInterface/Widget/RomBrowserWidget.hpp
+++ b/Source/RMG/UserInterface/Widget/RomBrowserWidget.hpp
@@ -72,6 +72,8 @@ class RomBrowserWidget : public QStackedWidget
     int listViewSortSection = 0;
     int listViewSortOrder = 0;
 
+    QStringList columnNames;
+
     QMenu*   contextMenu;
     QAction* action_PlayGame;
     QAction* action_PlayGameWith;
@@ -81,6 +83,7 @@ class RomBrowserWidget : public QStackedWidget
     QAction* action_RomInformation;
     QAction* action_EditGameSettings;
     QAction* action_EditCheats;
+    QAction* action_ResetColumnSizes;
     QAction* action_SetCoverImage;
     QAction* action_RemoveCoverImage;
 
@@ -126,6 +129,7 @@ class RomBrowserWidget : public QStackedWidget
     void on_Action_RomInformation(void);
     void on_Action_EditGameSettings(void);
     void on_Action_EditCheats(void);
+    void on_Action_ResetColumnSizes(void);
     void on_Action_SetCoverImage(void);
     void on_Action_RemoveCoverImage(void);
 


### PR DESCRIPTION
First there were [moveable columns...](https://github.com/Rosalie241/RMG/pull/105)

Next came the ability to [toggle columns on and off...](https://github.com/Rosalie241/RMG/pull/111)

And now, at long last, I'm proud to present the third and final phase of my grand plan to overhaul the ROM browser's "Game List" mode: **Additional Columns**. This is what it's all been leading up to!

![RMG_1](https://user-images.githubusercontent.com/70489593/222781523-0b36391b-821a-4594-9780-0bd68f905b92.png)
![RMG_2](https://user-images.githubusercontent.com/70489593/222781549-38dc7d82-a10b-4d7d-8d69-c39ed85d916f.png)
![RMG_3](https://user-images.githubusercontent.com/70489593/222781560-767e8585-52bf-45e3-92e7-d93576b8eb13.png)

This pull request implements the following changes:
- Six new columns (all of which are hidden by default) have been added to "Game List" mode in the ROM browser:
  - Game Format: Displays whether the ROM file is a disk or cartridge game. Listed as "Format" on the header to save space. Generated in "RMG-Core/Rom.cpp".
  - File Name: Displays the name of the ROM file, minus its file extension. Generated internally by "RomBrowserWidget.cpp".
  - File Extension: Displays the file extension of the ROM in all-caps. Listed as "File Ext." on the header to save space. Generated internally by "RomBrowserWidget.cpp".
  - File Size: Displays the size of the ROM file in megabytes. Listed as "Size" on the header to save space. Generated internally by "RomBrowserWidget.cpp".
  - Game I.D.: Displays the game's four-digit I.D. code, which is stored inside the ROM header from 0x3B to 0x3E. Listed as "I.D." on the header to save space. Generated in "RMG-Core/RomHeader.cpp" (see below).
  - Game Region: Displays the game's region, as determined by the last character in the I.D. code above. Listed as "Region" on the header to save space. Generated in "RMG-Core/RomHeader.cpp" (see below).
- "RMG-Core/RomHeader.cpp" has been updated to save a given ROM's Game I.D. and Game Region. "RMG-Core/CachedRomHeaderAndSettings.cpp" has also been updated to save these new properties to the cache so that the ROM browser can use them.
- In the "Rom Information" window, "Country Code" has been replaced with "Game I.D." and "Game Region".
- An option to resize all columns to their default widths has been added to the context menu in "Game List" mode. This works on all columns, regardless of whether they're hidden or not.
  - To accommodate this addition, portions of the code in "RomBrowserWidget.cpp" have been rewritten and reorganized. This also fixes a minor bug that causes the widths of columns that are hidden by default to be set incorrectly if the column's header name is longer than any of that column's content.

With this update, I believe that the "Game List" mode in RMG's ROM browser finally meets the standards set by those of other Qt-based emulators. If this PR gets merged, I might come back and make a few more minor tweaks and improvements at some point in the future, but for the most part, I think my work to improve the ROM browser is finally complete.

Whenever you have the time, be sure to look over the changes I've made and let me know what you think!