### PR TITLE
Init Translations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           sudo add-apt-repository ppa:okirby/qt6-backports --yes
           sudo apt-get -qq update
           sudo apt-get upgrade
-          sudo apt-get -y install cmake ninja-build libhidapi-dev libsamplerate0-dev libspeex-dev libminizip-dev libsdl2-dev libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev pkg-config zlib1g-dev binutils-dev libspeexdsp-dev qt6-base-dev qt6-tools-dev libqt6svg6-dev build-essential nasm git zip appstream
+          sudo apt-get -y install cmake ninja-build libhidapi-dev libsamplerate0-dev libspeex-dev libminizip-dev libsdl2-dev libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev pkg-config zlib1g-dev binutils-dev libspeexdsp-dev qt6-base-dev qt6-tools-dev qt6-l10n-tools libqt6svg6-dev build-essential nasm git zip appstream
       - name: Prepare Environment
         run: |
           echo "GIT_REVISION=$(git describe --tags --always)" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           sudo add-apt-repository ppa:okirby/qt6-backports --yes
           sudo apt-get -qq update
           sudo apt-get upgrade
-          sudo apt-get -y install cmake ninja-build libhidapi-dev libsamplerate0-dev libspeex-dev libminizip-dev libsdl2-dev libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev pkg-config zlib1g-dev binutils-dev libspeexdsp-dev qt6-base-dev qt6-tools-dev qt6-l10n-tools libqt6svg6-dev build-essential nasm git zip appstream
+          sudo apt-get -y install cmake ninja-build libhidapi-dev libsamplerate0-dev libspeex-dev libminizip-dev libsdl2-dev libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev pkg-config zlib1g-dev binutils-dev libspeexdsp-dev qt6-base-dev qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools libqt6svg6-dev build-essential nasm git zip appstream
       - name: Prepare Environment
         run: |
           echo "GIT_REVISION=$(git describe --tags --always)" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           sudo add-apt-repository ppa:okirby/qt6-backports --yes
           sudo apt-get -qq update
           sudo apt-get upgrade
-          sudo apt-get -y install cmake ninja-build libhidapi-dev libsamplerate0-dev libspeex-dev libminizip-dev libsdl2-dev libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev pkg-config zlib1g-dev binutils-dev libspeexdsp-dev qt6-base-dev libqt6svg6-dev build-essential nasm git zip appstream
+          sudo apt-get -y install cmake ninja-build libhidapi-dev libsamplerate0-dev libspeex-dev libminizip-dev libsdl2-dev libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev pkg-config zlib1g-dev binutils-dev libspeexdsp-dev qt6-base-dev qt6-tools-dev libqt6svg6-dev build-essential nasm git zip appstream
       - name: Prepare Environment
         run: |
           echo "GIT_REVISION=$(git describe --tags --always)" >> $GITHUB_ENV

--- a/Source/RMG/CMakeLists.txt
+++ b/Source/RMG/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt6 COMPONENTS Gui Widgets Core OpenGL REQUIRED)
+find_package(Qt6 COMPONENTS Gui Widgets Core OpenGL LinguistTools REQUIRED)
 
 if (PORTABLE_INSTALL)
     add_definitions(-DPORTABLE_INSTALL)
@@ -111,3 +111,7 @@ if (UPDATER)
     target_link_libraries(RMG Qt6::Network)
 endif(UPDATER)
 
+file(GLOB TS_FILES "Translations/*.ts")
+qt6_add_translations(RMG
+    TS_FILES ${TS_FILES}
+)

--- a/Source/RMG/Translations/RMG_de.ts
+++ b/Source/RMG/Translations/RMG_de.ts
@@ -1,0 +1,1823 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE">
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../UserInterface/Dialog/AboutDialog.ui" line="20"/>
+        <source>About RMG</source>
+        <translation>Über RMG</translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/AboutDialog.ui" line="71"/>
+        <source>An easy to use &amp; cross-platform mupen64plus front-end written in C++ &amp; Qt</source>
+        <translation>Ein einfach zu benutzendes, in C++ geschriebenes plattformunabhängiges Frontend für mupen64plus</translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/AboutDialog.ui" line="84"/>
+        <source>This program is licensed under GPLv3</source>
+        <translation>Dieses Programm ist lizensiert unter der GPLv3</translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/AboutDialog.ui" line="97"/>
+        <source>Copyright © 2020-2023 Rosalie Wanders</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AddCheatDialog</name>
+    <message>
+        <location filename="../UserInterface/Dialog/AddCheatDialog.ui" line="14"/>
+        <source>Add Cheat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/AddCheatDialog.ui" line="22"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/AddCheatDialog.ui" line="65"/>
+        <source>Author</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/AddCheatDialog.ui" line="104"/>
+        <source>Code:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/AddCheatDialog.ui" line="111"/>
+        <source>&lt;address&gt; &lt;value&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/AddCheatDialog.ui" line="132"/>
+        <source>Options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/AddCheatDialog.ui" line="139"/>
+        <source>&lt;value&gt; &lt;label&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/AddCheatDialog.ui" line="162"/>
+        <source>Notes:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CheatsDialog</name>
+    <message>
+        <location filename="../UserInterface/Dialog/CheatsDialog.ui" line="14"/>
+        <location filename="../UserInterface/Dialog/CheatsDialog.ui" line="39"/>
+        <source>Cheats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/CheatsDialog.ui" line="62"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/CheatsDialog.ui" line="72"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/CheatsDialog.ui" line="82"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/CheatsDialog.ui" line="110"/>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChooseCheatOptionDialog</name>
+    <message>
+        <location filename="../UserInterface/Dialog/ChooseCheatOptionDialog.ui" line="14"/>
+        <source>Choose Cheat Option</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/ChooseCheatOptionDialog.ui" line="24"/>
+        <source>Cheat Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ControllerWidget</name>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="20"/>
+        <source>ControllerWidget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="28"/>
+        <source>Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="53"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="66"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="95"/>
+        <source>Input Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="120"/>
+        <source>Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="143"/>
+        <source>Deadzone: 25%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="215"/>
+        <source>Digital Pad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="235"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="446"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="906"/>
+        <source>Up:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="248"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="459"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="919"/>
+        <source>Down:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="267"/>
+        <source>left:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="280"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="485"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="945"/>
+        <source>Right:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="306"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="337"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="368"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="399"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="511"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="536"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="561"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="586"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="658"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="703"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="784"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="832"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="971"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="1002"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="1033"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="1064"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="1144"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="1175"/>
+        <source>+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="313"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="344"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="375"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="406"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="518"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="543"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="568"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="593"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="665"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="710"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="791"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="839"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="978"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="1009"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="1040"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="1071"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="1151"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="1182"/>
+        <source>-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="426"/>
+        <source>Analog Stick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="472"/>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="932"/>
+        <source>Left:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="644"/>
+        <source>L-Trigger: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="689"/>
+        <source>R-Trigger: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="770"/>
+        <source>Start:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="818"/>
+        <source>Z-Trigger: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="886"/>
+        <source>C-Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="1105"/>
+        <source>B:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="1118"/>
+        <source>A:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="1209"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/Widget/ControllerWidget.ui" line="1216"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DownloadUpdateDialog</name>
+    <message>
+        <location filename="../UserInterface/Dialog/DownloadUpdateDialog.ui" line="14"/>
+        <source>Downloading Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/DownloadUpdateDialog.ui" line="20"/>
+        <source>Downloading ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>InstallUpdateDialog</name>
+    <message>
+        <location filename="../UserInterface/Dialog/InstallUpdateDialog.ui" line="14"/>
+        <source>Installing Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/InstallUpdateDialog.ui" line="20"/>
+        <source>Installing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LogDialog</name>
+    <message>
+        <location filename="../UserInterface/Dialog/LogDialog.ui" line="14"/>
+        <source>Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainDialog</name>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="14"/>
+        <source>Rosalie&apos;s Mupen GUI - Audio Plugin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="24"/>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="63"/>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="73"/>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="98"/>
+        <source>Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="106"/>
+        <source>Default Frequency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="130"/>
+        <source>Primary Buffer Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="154"/>
+        <source>Primary Buffer Target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="178"/>
+        <source>Secondary Buffer Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="202"/>
+        <source>Resampler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="210"/>
+        <source>trivial</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="215"/>
+        <source>speex-fixed-0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="220"/>
+        <source>speex-fixed-1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="225"/>
+        <source>speex-fixed-2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="230"/>
+        <source>speex-fixed-3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="235"/>
+        <source>speex-fixed-4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="240"/>
+        <source>speex-fixed-5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="245"/>
+        <source>speex-fixed-6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="250"/>
+        <source>speex-fixed-7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="255"/>
+        <source>speex-fixed-8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="260"/>
+        <source>speex-fixed-9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="265"/>
+        <source>speex-fixed-10</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="270"/>
+        <source>src-sinc-best-quality</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="275"/>
+        <source>src-sinc-medium-quality</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="280"/>
+        <source>src-sinc-fastest</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="285"/>
+        <source>src-zero-order-hold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="290"/>
+        <source>src-linear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="300"/>
+        <source>Swap Left And Right Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="307"/>
+        <source>Synchronize Audio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Audio/UserInterface/MainDialog.ui" line="354"/>
+        <source>Changes will be applied on next emulation run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/MainDialog.ui" line="14"/>
+        <source>Rosalie&apos;s Mupen GUI - Input Plugin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/MainDialog.ui" line="24"/>
+        <source>Player 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/MainDialog.ui" line="30"/>
+        <source>Player 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/MainDialog.ui" line="36"/>
+        <source>Player 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/MainDialog.ui" line="42"/>
+        <source>Player 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="14"/>
+        <source>Rosalie&apos;s Mupen GUI (VERSION)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="34"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="38"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="49"/>
+        <source>Current Save State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="71"/>
+        <source>Speed Factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="116"/>
+        <location filename="../UserInterface/MainWindow.ui" line="451"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="127"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="146"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="162"/>
+        <source>toolBar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="194"/>
+        <source>Start ROM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="203"/>
+        <source>Start Combo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="212"/>
+        <source>Shutdown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="221"/>
+        <source>Soft Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="230"/>
+        <source>Hard Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="242"/>
+        <source>Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="251"/>
+        <source>Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="263"/>
+        <source>Limit FPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="272"/>
+        <source>Save State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="281"/>
+        <source>Save As...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="290"/>
+        <source>Load State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="299"/>
+        <source>Load...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="307"/>
+        <source>Slot 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="315"/>
+        <source>Slot 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="323"/>
+        <source>Slot 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="331"/>
+        <source>Slot 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="339"/>
+        <source>Slot 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="347"/>
+        <source>Slot 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="355"/>
+        <source>Slot 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="363"/>
+        <source>Slot 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="371"/>
+        <source>Slot 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="379"/>
+        <source>Slot 9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="388"/>
+        <source>Cheats...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="397"/>
+        <source>GS Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="406"/>
+        <source>Exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="415"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="424"/>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="433"/>
+        <source>RSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="442"/>
+        <source>Audio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="460"/>
+        <source>Fullscreen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="469"/>
+        <source>Github Repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="478"/>
+        <source>About RMG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="490"/>
+        <source>Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="502"/>
+        <source>Status Bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="511"/>
+        <source>Game List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="520"/>
+        <source>Game Grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="529"/>
+        <source>Refresh ROMs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="538"/>
+        <source>Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="547"/>
+        <source>Clear ROM Cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="559"/>
+        <source>Uniform Size (Grid View)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="567"/>
+        <source>25%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="572"/>
+        <source>50%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="577"/>
+        <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="582"/>
+        <source>125%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="587"/>
+        <source>150%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="592"/>
+        <source>200%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="597"/>
+        <source>75%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="602"/>
+        <source>175%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="607"/>
+        <source>225%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="612"/>
+        <source>250%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="617"/>
+        <source>275%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="622"/>
+        <source>300%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.ui" line="631"/>
+        <source>Check For Updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="14"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="24"/>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="34"/>
+        <source>Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="42"/>
+        <source>Controller Pak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="50"/>
+        <source>Memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="55"/>
+        <source>Rumble</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="60"/>
+        <source>Transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="65"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="89"/>
+        <source>Transfer Pak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="95"/>
+        <source>Gameboy ROM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="108"/>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="131"/>
+        <source>Change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="118"/>
+        <source>Gameboy SAVE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="181"/>
+        <source>Changes will be applied on next emulation run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="195"/>
+        <source>User Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="201"/>
+        <source>Remove Duplicate Mappings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="208"/>
+        <source>Filter Events Based On Joystick Type For Buttons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RMG-Input/UserInterface/OptionsDialog.ui" line="215"/>
+        <source>Filter Events Based On Joystick Type For Axis</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RomBrowserEmptyWidget</name>
+    <message>
+        <location filename="../UserInterface/Widget/RomBrowserEmptyWidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Widget/RomBrowserEmptyWidget.ui" line="33"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;No ROMs in supported formats were found.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please select a directory with ROMs to begin.&lt;/p&gt;&lt;p&gt;ROMs in the following formats will be scanned and listed: &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Widget/RomBrowserEmptyWidget.ui" line="49"/>
+        <source>.n64/.z64/.v64 (N64 Roms)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Widget/RomBrowserEmptyWidget.ui" line="59"/>
+        <source>.ndd/.d64 (64DD Disks)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Widget/RomBrowserEmptyWidget.ui" line="69"/>
+        <source>.zip (Archive)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Widget/RomBrowserEmptyWidget.ui" line="94"/>
+        <source>Select ROM Directory...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Widget/RomBrowserEmptyWidget.ui" line="131"/>
+        <source>Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RomInfoDialog</name>
+    <message>
+        <location filename="../UserInterface/Dialog/RomInfoDialog.ui" line="14"/>
+        <source>ROM Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/RomInfoDialog.ui" line="34"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/RomInfoDialog.ui" line="67"/>
+        <source>File Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/RomInfoDialog.ui" line="100"/>
+        <source>Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/RomInfoDialog.ui" line="127"/>
+        <source>MD5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/RomInfoDialog.ui" line="154"/>
+        <source>CRC1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/RomInfoDialog.ui" line="178"/>
+        <source>CRC2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/RomInfoDialog.ui" line="202"/>
+        <source>Game I.D.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/RomInfoDialog.ui" line="226"/>
+        <source>Game Region</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialog</name>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="20"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1302"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1382"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="46"/>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="56"/>
+        <source>Emulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="62"/>
+        <source>Hide Cursor During Emulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="69"/>
+        <source>Hide Cursor During Fullscreen Emulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="76"/>
+        <source>Pause Emulation On Focus Loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="83"/>
+        <source>Resume Emulation On Focus Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="90"/>
+        <source>Automatically Switch To Fullscreen On Emulation Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="99"/>
+        <source>Statusbar Message Duration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="106"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="382"/>
+        <source> seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="164"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1724"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2290"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2482"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2836"/>
+        <source>Changes will be applied on next emulation run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="177"/>
+        <source>ROM Browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="183"/>
+        <source>Search Sub-Directories</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="190"/>
+        <source>Sort Results After Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="199"/>
+        <source>ROM Search Limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="232"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1438"/>
+        <source>Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="238"/>
+        <source>Show Verbose Messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="259"/>
+        <source>OSD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="265"/>
+        <source>Enable On-Screen Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="274"/>
+        <source>Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="282"/>
+        <source>Bottom Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="287"/>
+        <source>Top Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="292"/>
+        <source>Top Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="297"/>
+        <source>Bottom Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="309"/>
+        <source>Vertical Padding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="319"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="340"/>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="330"/>
+        <source>Horizontal Padding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="351"/>
+        <source>Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="375"/>
+        <source>Duration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="408"/>
+        <source>Miscellaneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="416"/>
+        <source>Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="424"/>
+        <source>Native</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="429"/>
+        <source>Fusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="434"/>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="446"/>
+        <source>Icon Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="454"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1552"/>
+        <source>Automatic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="459"/>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="464"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="474"/>
+        <source>Check For Updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="481"/>
+        <source>Discord Rich Presence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="531"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2680"/>
+        <source>Changes will be applied on next application run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="548"/>
+        <source>Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="576"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="584"/>
+        <source>Start ROM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="602"/>
+        <source>Start Combo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="620"/>
+        <source>Shutdown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="638"/>
+        <source>Hard Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="656"/>
+        <source>Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="674"/>
+        <source>Soft Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="692"/>
+        <source>Capture Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="710"/>
+        <source>Limit FPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="728"/>
+        <source>Save State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="746"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="764"/>
+        <source>Load State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="782"/>
+        <source>Load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="800"/>
+        <source>Cheats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="818"/>
+        <source>GS Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="836"/>
+        <source>Exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="866"/>
+        <source>Speed Factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="874"/>
+        <source>25%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="892"/>
+        <source>50%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="910"/>
+        <source>75%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="928"/>
+        <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="946"/>
+        <source>125%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="964"/>
+        <source>150%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="982"/>
+        <source>175%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1000"/>
+        <source>200%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1018"/>
+        <source>225%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1036"/>
+        <source>250%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1054"/>
+        <source>275%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1072"/>
+        <source>300%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1102"/>
+        <source>Current Save State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1110"/>
+        <source>Slot 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1128"/>
+        <source>Slot 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1146"/>
+        <source>Slot 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1164"/>
+        <source>Slot 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1182"/>
+        <source>Slot 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1200"/>
+        <source>Slot 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1218"/>
+        <source>Slot 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1236"/>
+        <source>Slot 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1254"/>
+        <source>Slot 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1272"/>
+        <source>Slot 9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1310"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1328"/>
+        <source>Audio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1346"/>
+        <source>RSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1364"/>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1412"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1420"/>
+        <source>Full Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1456"/>
+        <source>Refresh ROM List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1493"/>
+        <source>Remove Duplicate Keybindings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1501"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1927"/>
+        <source>Core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1509"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1947"/>
+        <source>CPU Emulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1517"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1955"/>
+        <source>Pure Interpreter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1522"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1960"/>
+        <source>Cached Interpreter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1527"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1965"/>
+        <source>Dynamic Recompiler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1539"/>
+        <source>Save Filename Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1547"/>
+        <source>Internal ROM Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1565"/>
+        <source>Override Game Specific Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1579"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1779"/>
+        <source>Memory Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1587"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1787"/>
+        <source>4 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1592"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1792"/>
+        <source>8 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1604"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1849"/>
+        <source>Counter Factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1612"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1857"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1990"/>
+        <source>1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1617"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1862"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1995"/>
+        <source>2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1622"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1867"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2000"/>
+        <source>3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1627"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1872"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2005"/>
+        <source>4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1632"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1877"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2010"/>
+        <source>5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1637"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1882"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2015"/>
+        <source>6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1649"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1894"/>
+        <source>SI DMA Duration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1674"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2050"/>
+        <source>Randomize PI/SI Interrupt Timing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1737"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1747"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1755"/>
+        <source>Good Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1804"/>
+        <source>Save Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1812"/>
+        <source>4 KB EEPROM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1817"/>
+        <source>16 KB EEPROM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1822"/>
+        <source>SRAM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1827"/>
+        <source>Flash RAM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1832"/>
+        <source>Controller pack</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1837"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1933"/>
+        <source>Override Core Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1977"/>
+        <source>Overclocking Factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="1985"/>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2020"/>
+        <source>7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2025"/>
+        <source>8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2030"/>
+        <source>9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2035"/>
+        <source>10</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2040"/>
+        <source>11</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2074"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2303"/>
+        <source>Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2083"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2309"/>
+        <source>Video Plugin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2111"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2328"/>
+        <source>Audio Plugin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2139"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2347"/>
+        <source>Input Plugin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2167"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2366"/>
+        <source>Reality Signal Processor Plugin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2241"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2437"/>
+        <source>Make sure to use a LLE RSP plugin (i.e paraLLEl RSP) when using a LLE Video plugin (i.e paraLLEl)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2495"/>
+        <source>Directories</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2501"/>
+        <source>Screenshot Directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2514"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2537"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2560"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2598"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2621"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2712"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2735"/>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2758"/>
+        <source>Change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2524"/>
+        <source>Save (State) Directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2547"/>
+        <source>Save (SRAM) Directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2573"/>
+        <source>Override User Directories</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2585"/>
+        <source>User Data Directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2608"/>
+        <source>User Cache Directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2693"/>
+        <source>64DD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2699"/>
+        <source>Japanese Retail 64DD IPL ROM path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2722"/>
+        <source>American Retail 64DD IPL ROM path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2745"/>
+        <source>Development 64DD IPL ROM path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2770"/>
+        <source>Disk Save Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2778"/>
+        <source>Full Disk Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/SettingsDialog.ui" line="2783"/>
+        <source>RAM Area Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UpdateDialog</name>
+    <message>
+        <location filename="../UserInterface/Dialog/UpdateDialog.ui" line="14"/>
+        <source>A new version is available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/UpdateDialog.ui" line="20"/>
+        <source>v0.2.2 Available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Dialog/UpdateDialog.ui" line="40"/>
+        <source>Don&apos;t check for updates again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UserInterface::MainWindow</name>
+    <message>
+        <location filename="../UserInterface/MainWindow.cpp" line="1339"/>
+        <source>Save State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.cpp" line="1339"/>
+        <source>Save State (*.state);;All Files (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.cpp" line="1382"/>
+        <source>Open Save State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/MainWindow.cpp" line="1382"/>
+        <source>Save State (*.dat *.state);;All Files (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UserInterface::Widget::RomBrowserWidget</name>
+    <message>
+        <location filename="../UserInterface/Widget/RomBrowserWidget.cpp" line="937"/>
+        <source>Open Cover Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UserInterface/Widget/RomBrowserWidget.cpp" line="937"/>
+        <source>Cover Image (*.png *.jpeg *.jpg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/Source/RMG/main.cpp
+++ b/Source/RMG/main.cpp
@@ -11,6 +11,8 @@
 
 #include <QApplication>
 #include <QCommandLineParser>
+#include <QLibraryInfo>
+#include <QTranslator>
 #include <QDir>
 #include <QFile>
 
@@ -95,6 +97,16 @@ int main(int argc, char **argv)
 #endif // FORCE_XCB
 
     QApplication app(argc, argv);
+
+    QTranslator appTranslator;
+    if (appTranslator.load(QLocale(), QLatin1String("RMG"), QLatin1String("_"), QLatin1String(":/i18n"))) {
+        QCoreApplication::installTranslator(&appTranslator);
+    }
+
+    QTranslator qtTranslator;
+    if (qtTranslator.load(QLocale(), QLatin1String("qt"), QLatin1String("_"), QLibraryInfo::path(QLibraryInfo::LibraryPath::TranslationsPath))) {
+        QCoreApplication::installTranslator(&qtTranslator);
+    }
 
     UserInterface::MainWindow window;
 


### PR DESCRIPTION
This PR adds initial Support for translations.  It's alrady fully working, but you need to prepare your code a little. On Every string that should be translated replace
```cpp
"my String"
```
with
```cpp
tr("my String")
```
If you have something in your ui files that should not be translated e.g. a Placeholder text, you should mark it as not translatable.

You can add new languages by running
```shell
lupdate . -ts ./Translations/RMG_de.ts
```
In the `Source `directory

It can also be used with [Weblate](https://hosted.weblate.org)

I added a German translation with currently only includes the About Dialog as Example.