### PR TITLE
Introduce analog stick sensitivity

### DIFF
--- a/Source/RMG-Core/Settings/Settings.cpp
+++ b/Source/RMG-Core/Settings/Settings.cpp
@@ -637,6 +637,9 @@ static l_Setting get_setting(SettingsID settingId)
     case SettingsID::Input_Deadzone:
         setting = {"", "Deadzone"};
         break;
+    case SettingsID::Input_Sensitivity:
+        setting = {"", "Sensitivity"};
+        break;
     case SettingsID::Input_Pak:
         setting = {"", "Pak"};
         break;

--- a/Source/RMG-Core/Settings/SettingsID.hpp
+++ b/Source/RMG-Core/Settings/SettingsID.hpp
@@ -188,6 +188,7 @@ enum class SettingsID
     Input_DeviceName,
     Input_DeviceNum,
     Input_Deadzone,
+    Input_Sensitivity,
     Input_Pak,
     Input_GameboyRom,
     Input_GameboySave,

--- a/Source/RMG-Input/UserInterface/Widget/ControllerImageWidget.hpp
+++ b/Source/RMG-Input/UserInterface/Widget/ControllerImageWidget.hpp
@@ -31,6 +31,8 @@ private:
     int yAxisState = 0;
     // deadzone value, 0-100
     int deadzoneValue = 0;
+    // sensitivity value, 25-175
+    int sensitivityValue = 100;
 
     bool needImageUpdate = false;
 public:
@@ -41,6 +43,7 @@ public:
     void SetXAxisState(int xAxis);
     void SetYAxisState(int yAxis);
     void SetDeadzone(int value);
+    void SetSensitivity(int value);
 
     void ClearControllerState();
     void UpdateImage();

--- a/Source/RMG-Input/UserInterface/Widget/ControllerWidget.cpp
+++ b/Source/RMG-Input/UserInterface/Widget/ControllerWidget.cpp
@@ -517,6 +517,7 @@ void ControllerWidget::on_analogStickSensitivitySlider_valueChanged(int value)
     title += "%";
 
     this->analogStickSensitivityGroupBox->setTitle(title);
+    this->controllerImageWidget->SetSensitivity(value);
 }
 
 void ControllerWidget::on_profileComboBox_currentIndexChanged(int value)

--- a/Source/RMG-Input/UserInterface/Widget/ControllerWidget.cpp
+++ b/Source/RMG-Input/UserInterface/Widget/ControllerWidget.cpp
@@ -323,6 +323,7 @@ void ControllerWidget::setPluggedIn(bool value)
         this->analogStickDownButton, this->analogStickDownAddButton, this->analogStickDownRemoveButton,
         this->analogStickLeftButton, this->analogStickLeftAddButton, this->analogStickLeftRemoveButton,
         this->analogStickRightButton, this->analogStickRightAddButton, this->analogStickRightRemoveButton,
+        this->analogStickSensitivitySlider,
         // cbuttons
         this->cButtonsGroupBox,
         this->cbuttonUpButton, this->cbuttonUpAddButton, this->cbuttonUpRemoveButton,
@@ -507,6 +508,15 @@ void ControllerWidget::on_deadZoneSlider_valueChanged(int value)
 
     this->deadZoneGroupBox->setTitle(title);
     this->controllerImageWidget->SetDeadzone(value);
+}
+
+void ControllerWidget::on_analogStickSensitivitySlider_valueChanged(int value)
+{
+    QString title = tr("Analog Stick Sensitivity: ");
+    title += QString::number(value);
+    title += "%";
+
+    this->analogStickSensitivityGroupBox->setTitle(title);
 }
 
 void ControllerWidget::on_profileComboBox_currentIndexChanged(int value)
@@ -1232,6 +1242,7 @@ void ControllerWidget::LoadSettings(QString sectionQString, bool loadUserProfile
         }
     }
 
+    this->analogStickSensitivitySlider->setValue(CoreSettingsGetIntValue(SettingsID::Input_Sensitivity, section));
     this->deadZoneSlider->setValue(CoreSettingsGetIntValue(SettingsID::Input_Deadzone, section));
     this->optionsDialogSettings.RemoveDuplicateMappings = CoreSettingsGetBoolValue(SettingsID::Input_RemoveDuplicateMappings, section);
     this->optionsDialogSettings.ControllerPak = CoreSettingsGetIntValue(SettingsID::Input_Pak, section);
@@ -1309,6 +1320,7 @@ void ControllerWidget::SaveDefaultSettings()
     CoreSettingsSetValue(SettingsID::Input_DeviceName, section, std::string("None"));
     CoreSettingsSetValue(SettingsID::Input_DeviceNum, section, (int)InputDeviceType::None);
     CoreSettingsSetValue(SettingsID::Input_Deadzone, section, 9);
+    CoreSettingsSetValue(SettingsID::Input_Sensitivity, section, 100);
     CoreSettingsSetValue(SettingsID::Input_Pak, section, 0);
     CoreSettingsSetValue(SettingsID::Input_RemoveDuplicateMappings, section, true);
     CoreSettingsSetValue(SettingsID::Input_FilterEventsForButtons, section, true);
@@ -1393,6 +1405,7 @@ void ControllerWidget::SaveSettings(QString section)
     CoreSettingsSetValue(SettingsID::Input_DeviceName, sectionStr, deviceName.toStdString());
     CoreSettingsSetValue(SettingsID::Input_DeviceNum, sectionStr, deviceNum);
     CoreSettingsSetValue(SettingsID::Input_Deadzone, sectionStr, this->deadZoneSlider->value());
+    CoreSettingsSetValue(SettingsID::Input_Sensitivity, sectionStr, this->analogStickSensitivitySlider->value());
     CoreSettingsSetValue(SettingsID::Input_Pak, sectionStr, this->optionsDialogSettings.ControllerPak);
     CoreSettingsSetValue(SettingsID::Input_GameboyRom, sectionStr, this->optionsDialogSettings.GameboyRom);
     CoreSettingsSetValue(SettingsID::Input_GameboySave, sectionStr, this->optionsDialogSettings.GameboySave);

--- a/Source/RMG-Input/UserInterface/Widget/ControllerWidget.hpp
+++ b/Source/RMG-Input/UserInterface/Widget/ControllerWidget.hpp
@@ -138,6 +138,7 @@ public:
 
 private slots:
     void on_deadZoneSlider_valueChanged(int value);
+    void on_analogStickSensitivitySlider_valueChanged(int value);
     
     void on_profileComboBox_currentIndexChanged(int value);
 

--- a/Source/RMG-Input/UserInterface/Widget/ControllerWidget.ui
+++ b/Source/RMG-Input/UserInterface/Widget/ControllerWidget.ui
@@ -602,6 +602,43 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="analogStickSensitivityGroupBox">
+         <property name="title">
+          <string>Analog Stick Sensitivity: 100%</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_15">
+          <item>
+           <widget class="QSlider" name="analogStickSensitivitySlider">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimum">
+             <number>25</number>
+            </property>
+            <property name="maximum">
+             <number>175</number>
+            </property>
+            <property name="value">
+             <number>100</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="tickPosition">
+             <enum>QSlider::TicksBelow</enum>
+            </property>
+            <property name="tickInterval">
+             <number>15</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/Source/RMG-Input/main.cpp
+++ b/Source/RMG-Input/main.cpp
@@ -60,6 +60,7 @@ struct InputProfile
 {
     bool PluggedIn    = false;
     int DeadzoneValue = 0;
+    int SensitivityValue = 100;
 
     N64ControllerPak ControllerPak = N64ControllerPak::None;
 
@@ -217,6 +218,7 @@ static void load_settings(void)
 
         profile->PluggedIn = CoreSettingsGetBoolValue(SettingsID::Input_PluggedIn, section);
         profile->DeadzoneValue = CoreSettingsGetIntValue(SettingsID::Input_Deadzone, section);
+        profile->SensitivityValue = CoreSettingsGetIntValue(SettingsID::Input_Sensitivity, section);
         profile->ControllerPak = (N64ControllerPak)CoreSettingsGetIntValue(SettingsID::Input_Pak, section);
         profile->DeviceName = CoreSettingsGetStringValue(SettingsID::Input_DeviceName, section);
         profile->DeviceNum = CoreSettingsGetIntValue(SettingsID::Input_DeviceNum, section);
@@ -880,7 +882,7 @@ EXPORT void CALL GetKeys(int Control, BUTTONS* Keys)
         inputX, // inputX
         inputY, // inputY
         profile->DeadzoneValue / 100.0, // deadzoneFactor
-        1.0, // sensitivityFactor
+        profile->SensitivityValue / 100.0, // sensitivityFactor
         octagonX, // outputX
         octagonY  // outputY
     );


### PR DESCRIPTION
Allow users to set a sensitivity for analog stick input. The range is from 25% to 175% of the actual input. Lower than 100% sensitivity will result in not being able to reach maximum emulated N64 input; i.e. lower than 85 absolute value along the axes. Greater than 100% sensitivity causes the emulated input to reach its max sooner than. When emulated stick input is mapped to a digital input on the real input device, e.g. a keyboard, values under 100% will limit the maximum value similarly to analog mappings, while values above 100% will have no impact on the emulated input.