### PR TITLE
Download linuxdeploy less often

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,13 @@ jobs:
           sudo apt-get -qq update
           sudo apt-get upgrade
           sudo apt-get -y install cmake ninja-build libhidapi-dev libsamplerate0-dev libspeex-dev libminizip-dev libsdl2-dev libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev pkg-config zlib1g-dev binutils-dev libspeexdsp-dev qt6-base-dev libqt6svg6-dev build-essential nasm git zip appstream
+          packaging_tools_dir="$(pwd)/Package/AppImage"
+          curl -L https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -o "$packaging_tool_dir/linuxdeploy-x86_64.AppImage"
+          chmod +x "$packaging_tools_dir/linuxdeploy-x86_64.AppImage"
+          curl -L https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage -o "$packaging_tools_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
+          chmod +x "$packaging_tools_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
+          "$packaging_tools_dir/linuxdeploy-plugin-qt-x86_64.AppImage" --appimage-extract
+          "$packaging_tools_dir/linuxdeploy-x86_64.AppImage" --appimage-extract
       - name: Prepare Environment
         run: |
           echo "GIT_REVISION=$(git describe --tags --always)" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get -qq update
           sudo apt-get upgrade
           sudo apt-get -y install cmake ninja-build libhidapi-dev libsamplerate0-dev libspeex-dev libminizip-dev libsdl2-dev libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev pkg-config zlib1g-dev binutils-dev libspeexdsp-dev qt6-base-dev libqt6svg6-dev build-essential nasm git zip appstream
-          packaging_tools_dir="$(pwd)/Package/AppImage"
+          export packaging_tools_dir="$(pwd)/Package/AppImage"
           curl -L https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -o "$packaging_tool_dir/linuxdeploy-x86_64.AppImage"
           chmod +x "$packaging_tools_dir/linuxdeploy-x86_64.AppImage"
           curl -L https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage -o "$packaging_tools_dir/linuxdeploy-plugin-qt-x86_64.AppImage"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
           sudo apt-get -qq update
           sudo apt-get upgrade
           sudo apt-get -y install cmake ninja-build libhidapi-dev libsamplerate0-dev libspeex-dev libminizip-dev libsdl2-dev libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev pkg-config zlib1g-dev binutils-dev libspeexdsp-dev qt6-base-dev libqt6svg6-dev build-essential nasm git zip appstream
-          export packaging_tools_dir="$(pwd)/Package/AppImage"
-          curl -L https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -o "$packaging_tool_dir/linuxdeploy-x86_64.AppImage"
+          packaging_tools_dir="$(pwd)/Package/AppImage"
+          curl -L https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -o "$packaging_tools_dir/linuxdeploy-x86_64.AppImage"
           chmod +x "$packaging_tools_dir/linuxdeploy-x86_64.AppImage"
           curl -L https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage -o "$packaging_tools_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
           chmod +x "$packaging_tools_dir/linuxdeploy-plugin-qt-x86_64.AppImage"

--- a/Package/AppImage/Create.sh
+++ b/Package/AppImage/Create.sh
@@ -16,7 +16,7 @@ then
 fi
 if [ "$1" = "--no-appimage" ]
 then
-    output_args="--output="
+    output_args=""
 fi
 
 export QMAKE="$(which qmake6)"

--- a/Package/AppImage/Create.sh
+++ b/Package/AppImage/Create.sh
@@ -11,27 +11,6 @@ export VERSION="$(git describe --tags --always)"
 export OUTPUT="$bin_dir/../RMG-Portable-Linux64-$VERSION.AppImage"
 export LD_LIBRARY_PATH="$toplvl_dir/Build/AppImage/Source/RMG-Core" # hack
 
-if [ ! -f "$script_dir/linuxdeploy-x86_64.AppImage" ]
-then
-    curl -L https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage \
-        -o "$script_dir/linuxdeploy-x86_64.AppImage"
-    chmod +x "$script_dir/linuxdeploy-x86_64.AppImage"
-fi
-
-if [ ! -f "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage" ]
-then
-    curl -L https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage \
-        -o "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
-    chmod +x "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
-fi
-
-"$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage" --appimage-extract
-"$script_dir/linuxdeploy-x86_64.AppImage" --appimage-extract
-
-# delete appimages
-rm "$script_dir/linuxdeploy-x86_64.AppImage" \
-    "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
-
 "$(pwd)/squashfs-root/AppRun" \
     --plugin=qt \
     --appdir="$bin_dir" \

--- a/Package/AppImage/Create.sh
+++ b/Package/AppImage/Create.sh
@@ -4,20 +4,6 @@ set -ex
 script_dir="$(dirname "$0")"
 toplvl_dir="$(realpath "$script_dir/../../")"
 bin_dir="$toplvl_dir/Bin/AppImage" # RMG should be installed here
-output_args="--output=appimage"
-
-if [ "$1" = "--help" ] ||
-    [ "$1" = "-h" ]
-then
-    echo "$0 [--no-appimage]"
-    echo "--no-appimage: skip creating a single .AppImage file, "
-    echo "the application can be run from the AppImage folder."
-    exit
-fi
-if [ "$1" = "--no-appimage" ]
-then
-    output_args = ""
-fi
 
 export QMAKE="$(which qmake6)"
 export EXTRA_QT_PLUGINS="imageformats;iconengines;"
@@ -50,5 +36,5 @@ rm "$script_dir/linuxdeploy-x86_64.AppImage" \
     --plugin=qt \
     --appdir="$bin_dir" \
     --custom-apprun="$script_dir/AppRun" \
-    $output_args \
+    --output=appimage \
     --desktop-file="$bin_dir/usr/share/applications/com.github.Rosalie241.RMG.desktop"

--- a/Package/AppImage/Create.sh
+++ b/Package/AppImage/Create.sh
@@ -17,4 +17,3 @@ export LD_LIBRARY_PATH="$toplvl_dir/Build/AppImage/Source/RMG-Core" # hack
     --custom-apprun="$script_dir/AppRun" \
     --output=appimage \
     --desktop-file="$bin_dir/usr/share/applications/com.github.Rosalie241.RMG.desktop"
-

--- a/Package/AppImage/Create.sh
+++ b/Package/AppImage/Create.sh
@@ -10,13 +10,13 @@ if [ "$1" = "--help" ] ||
     [ "$1" = "-h" ]
 then
     echo "$0 [--no-appimage]"
-    echo "--no-appimage: skip creating a compressed .AppImage file, "
-    echo "only the AppImage folder will be created."
+    echo "--no-appimage: skip creating a single .AppImage file, "
+    echo "the application can be run from the AppImage folder."
     exit
 fi
 if [ "$1" = "--no-appimage" ]
 then
-    output_args="--output="
+    output_args = ""
 fi
 
 export QMAKE="$(which qmake6)"
@@ -24,6 +24,27 @@ export EXTRA_QT_PLUGINS="imageformats;iconengines;"
 export VERSION="$(git describe --tags --always)"
 export OUTPUT="$bin_dir/../RMG-Portable-Linux64-$VERSION.AppImage"
 export LD_LIBRARY_PATH="$toplvl_dir/Build/AppImage/Source/RMG-Core" # hack
+
+if [ ! -f "$script_dir/linuxdeploy-x86_64.AppImage" ]
+then
+    curl -L https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage \
+        -o "$script_dir/linuxdeploy-x86_64.AppImage"
+    chmod +x "$script_dir/linuxdeploy-x86_64.AppImage"
+fi
+
+if [ ! -f "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage" ]
+then
+    curl -L https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage \
+        -o "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
+    chmod +x "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
+fi
+
+"$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage" --appimage-extract
+"$script_dir/linuxdeploy-x86_64.AppImage" --appimage-extract
+
+# delete appimages
+rm "$script_dir/linuxdeploy-x86_64.AppImage" \
+    "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
 
 "$(pwd)/squashfs-root/AppRun" \
     --plugin=qt \

--- a/Package/AppImage/Create.sh
+++ b/Package/AppImage/Create.sh
@@ -17,3 +17,4 @@ export LD_LIBRARY_PATH="$toplvl_dir/Build/AppImage/Source/RMG-Core" # hack
     --custom-apprun="$script_dir/AppRun" \
     --output=appimage \
     --desktop-file="$bin_dir/usr/share/applications/com.github.Rosalie241.RMG.desktop"
+

--- a/Package/AppImage/Create.sh
+++ b/Package/AppImage/Create.sh
@@ -10,13 +10,13 @@ if [ "$1" = "--help" ] ||
     [ "$1" = "-h" ]
 then
     echo "$0 [--no-appimage]"
-    echo "--no-appimage: skip creating a single .AppImage file, "
-    echo "the application can be run from the AppImage folder."
+    echo "--no-appimage: skip creating a compressed .AppImage file, "
+    echo "only the AppImage folder will be created."
     exit
 fi
 if [ "$1" = "--no-appimage" ]
 then
-    output_args = ""
+    output_args=""
 fi
 
 export QMAKE="$(which qmake6)"
@@ -38,6 +38,7 @@ then
         -o "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
     chmod +x "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
 fi
+
 
 "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage" --appimage-extract
 "$script_dir/linuxdeploy-x86_64.AppImage" --appimage-extract

--- a/Package/AppImage/Create.sh
+++ b/Package/AppImage/Create.sh
@@ -4,6 +4,20 @@ set -ex
 script_dir="$(dirname "$0")"
 toplvl_dir="$(realpath "$script_dir/../../")"
 bin_dir="$toplvl_dir/Bin/AppImage" # RMG should be installed here
+output_args="--output=appimage"
+
+if [ "$1" = "--help" ] ||
+    [ "$1" = "-h" ]
+then
+    echo "$0 [--no-appimage]"
+    echo "--no-appimage: skip creating a single .AppImage file, "
+    echo "the application can be run from the AppImage folder."
+    exit
+fi
+if [ "$1" = "--no-appimage" ]
+then
+    output_args = ""
+fi
 
 export QMAKE="$(which qmake6)"
 export EXTRA_QT_PLUGINS="imageformats;iconengines;"
@@ -36,5 +50,5 @@ rm "$script_dir/linuxdeploy-x86_64.AppImage" \
     --plugin=qt \
     --appdir="$bin_dir" \
     --custom-apprun="$script_dir/AppRun" \
-    --output=appimage \
+    $output_args \
     --desktop-file="$bin_dir/usr/share/applications/com.github.Rosalie241.RMG.desktop"

--- a/Package/AppImage/Create.sh
+++ b/Package/AppImage/Create.sh
@@ -16,7 +16,7 @@ then
 fi
 if [ "$1" = "--no-appimage" ]
 then
-    output_args=""
+    output_args="--output="
 fi
 
 export QMAKE="$(which qmake6)"
@@ -24,28 +24,6 @@ export EXTRA_QT_PLUGINS="imageformats;iconengines;"
 export VERSION="$(git describe --tags --always)"
 export OUTPUT="$bin_dir/../RMG-Portable-Linux64-$VERSION.AppImage"
 export LD_LIBRARY_PATH="$toplvl_dir/Build/AppImage/Source/RMG-Core" # hack
-
-if [ ! -f "$script_dir/linuxdeploy-x86_64.AppImage" ]
-then
-    curl -L https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage \
-        -o "$script_dir/linuxdeploy-x86_64.AppImage"
-    chmod +x "$script_dir/linuxdeploy-x86_64.AppImage"
-fi
-
-if [ ! -f "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage" ]
-then
-    curl -L https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage \
-        -o "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
-    chmod +x "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
-fi
-
-
-"$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage" --appimage-extract
-"$script_dir/linuxdeploy-x86_64.AppImage" --appimage-extract
-
-# delete appimages
-rm "$script_dir/linuxdeploy-x86_64.AppImage" \
-    "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
 
 "$(pwd)/squashfs-root/AppRun" \
     --plugin=qt \

--- a/Package/AppImage/Create.sh
+++ b/Package/AppImage/Create.sh
@@ -16,7 +16,7 @@ then
 fi
 if [ "$1" = "--no-appimage" ]
 then
-    output_args=""
+    output_args="--output="
 fi
 
 export QMAKE="$(which qmake6)"


### PR DESCRIPTION
When I am building the Linux .AppImage interactively I don't need the current linuxdeploy tools to be downloaded each time. This script moves the download and unpacking of the linux deploy tools to the build.yml script alongside the download of other build tools.

Currently Package/AppImage/Create.sh does this 
- checks if linuxdeploy .AppImage files exist in Package/AppImage
- downloads them to Package/AppImage if not
- unpacks them to $(pwd)/squashfs_root (pwd is RMG)
- deletes the .AppImage files
- (the unpacked squashfs_root is left in place)

Moving the download and unpack to the build.yml script is intended to helpfully simplify the Package/AppImage/Create.sh script and move the build environment tool installations all together in build.yml. 
