### PR TITLE
Allow Package/AppImage/Create.sh to skip .AppImage file creation

### DIFF
--- a/Package/AppImage/Create.sh
+++ b/Package/AppImage/Create.sh
@@ -4,6 +4,20 @@ set -ex
 script_dir="$(dirname "$0")"
 toplvl_dir="$(realpath "$script_dir/../../")"
 bin_dir="$toplvl_dir/Bin/AppImage" # RMG should be installed here
+output_args="--output=appimage"
+
+if [ "$1" = "--help" ] ||
+    [ "$1" = "-h" ]
+then
+    echo "$0 [--folder-only]"
+    echo "--folder-only: skip creating a compressed .AppImage file, "
+    echo "only the AppImage folder will be created."
+    exit
+fi
+if [ "$1" = "--folder-only" ]
+then
+    output_args=""
+fi
 
 export QMAKE="$(which qmake6)"
 export EXTRA_QT_PLUGINS="imageformats;iconengines;"
@@ -36,5 +50,5 @@ rm "$script_dir/linuxdeploy-x86_64.AppImage" \
     --plugin=qt \
     --appdir="$bin_dir" \
     --custom-apprun="$script_dir/AppRun" \
-    --output=appimage \
+    $output_args \
     --desktop-file="$bin_dir/usr/share/applications/com.github.Rosalie241.RMG.desktop"


### PR DESCRIPTION
Allow Package/AppImage/Create.sh to skip .AppImage file creation with --folder-only

I am building an AppImage in an ubuntu container to deploy to the local host, a Steam Deck with a read-only root filesystem. After the build, I deploy the unpacked AppImage folder, and I do not need the compressed squashfs .AppImage file that is created.

This change allows my build script to easily skip the .AppImage compression, saving me time and wear on my disk. No change is needed to the current .github/workflows/build.yml