### PR TITLE
Linuxdeploy download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,13 @@ jobs:
           sudo apt-get -qq update
           sudo apt-get upgrade
           sudo apt-get -y install cmake ninja-build libhidapi-dev libsamplerate0-dev libspeex-dev libminizip-dev libsdl2-dev libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev pkg-config zlib1g-dev binutils-dev libspeexdsp-dev qt6-base-dev libqt6svg6-dev build-essential nasm git zip appstream
+          packaging_tools_dir="$(pwd)/Package/AppImage"
+          curl -L https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -o "$packaging_tools_dir/linuxdeploy-x86_64.AppImage"
+          chmod +x "$packaging_tools_dir/linuxdeploy-x86_64.AppImage"
+          curl -L https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage -o "$packaging_tools_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
+          chmod +x "$packaging_tools_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
+          "$packaging_tools_dir/linuxdeploy-plugin-qt-x86_64.AppImage" --appimage-extract
+          "$packaging_tools_dir/linuxdeploy-x86_64.AppImage" --appimage-extract
       - name: Prepare Environment
         run: |
           echo "GIT_REVISION=$(git describe --tags --always)" >> $GITHUB_ENV

--- a/Package/AppImage/Create.sh
+++ b/Package/AppImage/Create.sh
@@ -11,27 +11,6 @@ export VERSION="$(git describe --tags --always)"
 export OUTPUT="$bin_dir/../RMG-Portable-Linux64-$VERSION.AppImage"
 export LD_LIBRARY_PATH="$toplvl_dir/Build/AppImage/Source/RMG-Core" # hack
 
-if [ ! -f "$script_dir/linuxdeploy-x86_64.AppImage" ]
-then
-    curl -L https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage \
-        -o "$script_dir/linuxdeploy-x86_64.AppImage"
-    chmod +x "$script_dir/linuxdeploy-x86_64.AppImage"
-fi
-
-if [ ! -f "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage" ]
-then
-    curl -L https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage \
-        -o "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
-    chmod +x "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
-fi
-
-"$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage" --appimage-extract
-"$script_dir/linuxdeploy-x86_64.AppImage" --appimage-extract
-
-# delete appimages
-rm "$script_dir/linuxdeploy-x86_64.AppImage" \
-    "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
-
 "$(pwd)/squashfs-root/AppRun" \
     --plugin=qt \
     --appdir="$bin_dir" \

--- a/Package/AppImage/GetLinuxdeployTools.sh
+++ b/Package/AppImage/GetLinuxdeployTools.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -ex
+
+script_dir="$(realpath $(dirname "$0"))"
+toplvl_dir="$(realpath "$script_dir/../../")"
+
+# A script that needs to be run once to get the linuxdeploy tools
+# that are used to create AppImages. The .github/workflows/build.yml
+# does this setup in the Install Packages step on the build server,
+# but this must be run before building an appimage on a local machine.
+
+if [ ! -f "$script_dir/linuxdeploy-x86_64.AppImage" ]
+then
+    curl -L https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage \
+        -o "$script_dir/linuxdeploy-x86_64.AppImage"
+    chmod +x "$script_dir/linuxdeploy-x86_64.AppImage"
+fi
+
+if [ ! -f "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage" ]
+then
+    curl -L https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage \
+        -o "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
+    chmod +x "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
+fi
+
+# To mirror .github/workflows/build.yml this script will always unpack
+# the linuxdeploy tools to $toplvl_dir/squashfs
+pushd "$toplvl_dir"
+"$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage" --appimage-extract
+"$script_dir/linuxdeploy-x86_64.AppImage" --appimage-extract
+popd
+
+# delete appimages
+rm "$script_dir/linuxdeploy-x86_64.AppImage" \
+    "$script_dir/linuxdeploy-plugin-qt-x86_64.AppImage"
+


### PR DESCRIPTION
When I am building the Linux .AppImage interactively I don't need the current linuxdeploy tools to be downloaded each time. This script moves the download and unpacking of the linuxdeploy tools to the build.yml script alongside the download of other build tools.

Currently Package/AppImage/Create.sh does this:
- checks if linuxdeploy .AppImage files exist in Package/AppImage
- downloads them to Package/AppImage if not
- unpacks them to $(pwd)/squashfs_root (pwd is RMG)
- deletes the .AppImage files
- (the unpacked squashfs_root is left in place)

Moving the download and unpack to the build.yml script is intended to helpfully simplify the Package/AppImage/Create.sh script and move the build environment tool installations all together in build.yml.

To make it easy to setup the linuxdeploy tools in a manual build I've copied the setup steps in to GetLinuxdeployTools.sh. Maybe this isn't wanted, or maybe the build.yml should call GetLinuxdeployTools.sh for consistency and to avoid duplication?