### PR TITLE
Add 'RMG' as a keyword to the desktop entry

### DIFF
--- a/Package/com.github.Rosalie241.RMG.desktop
+++ b/Package/com.github.Rosalie241.RMG.desktop
@@ -7,3 +7,4 @@ Icon=com.github.Rosalie241.RMG
 Terminal=false
 Categories=Game;Emulator;Qt;
 MimeType=application/x-n64-rom;
+Keywords=RMG


### PR DESCRIPTION
Right now (in GNOME at least), when you type "RMG", this application doesn't come up.

Adding "RMG" as a Keyword in the desktop entry should allow a person to type "RMG" and GNOME search will find it and suggest it.