### PR TITLE
Don't strip (debug symbols) from debug builds

### DIFF
--- a/Source/Script/Build.sh
+++ b/Source/Script/Build.sh
@@ -18,7 +18,13 @@ mkdir -p "$build_dir"
 cmake -S "$toplvl_dir" -B "$build_dir" -DCMAKE_BUILD_TYPE="$build_config" -DPORTABLE_INSTALL=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -G "Ninja"
 
 cmake --build "$build_dir" --parallel "$threads"
-cmake --install "$build_dir" --strip --prefix="$toplvl_dir"
+
+strip_args=" --strip "
+if [ "$build_config"="Debug" ]
+then
+    strip_args=" "
+fi
+cmake --install "$build_dir" $strip_args --prefix="$toplvl_dir"
 
 if [[ $(uname -s) = *MINGW64* ]]
 then


### PR DESCRIPTION
Don't strip Debug builds so that Debug builds can be debugged. 

I think that if you choose to create a debug build that you will not want the binaries stripped. 