### PR TITLE
RMG-Input: improve control stick behavior

### DIFF
--- a/Source/RMG-Input/main.cpp
+++ b/Source/RMG-Input/main.cpp
@@ -760,10 +760,9 @@ static double apply_deadzone(const double input, const double deadzone)
 // Credit: MerryMage, fzurita & kev4cards
 static void simulate_octagon(const double deadzone, const double inputX, const double inputY, int& outputX, int& outputY)
 {
-    // don't increase emulated range at higher than 100% sensitivity
     const double maxAxis     = N64_AXIS_PEAK;
     const double maxDiagonal = MAX_DIAGONAL_VALUE;
-    const double maxInputRadius = sqrt(2) * maxAxis * (maxDiagonal / maxAxis * (1.0 - deadzone) + deadzone);
+    const double maxInputRadius = sqrt(2) * (maxDiagonal + deadzone * (maxAxis - maxDiagonal));
     // scale to [-maxInputRadius, maxInputRadius]
     double ax = inputX * maxInputRadius;
     double ay = inputY * maxInputRadius;

--- a/Source/RMG-Input/main.cpp
+++ b/Source/RMG-Input/main.cpp
@@ -798,10 +798,6 @@ static void simulate_octagon(const double deadzone, const double inputX, const d
     if(std::abs(ax) > maxAxis) ax = std::copysign(maxAxis, ax);
     if(std::abs(ay) > maxAxis) ay = std::copysign(maxAxis, ay);
 
-    // prevent floating point precision error keeping values lower than they should be prior to truncation
-    ax = std::copysign(std::abs(ax) + 1e-09, ax);
-    ay = std::copysign(std::abs(ay) + 1e-09, ay);
-
     outputX = (int)ax;
     outputY = (int)ay;
 }


### PR DESCRIPTION
This PR replaces PR #142. It addresses the comments from that PR as well as reworked to fit into the recent refactor. The code is designed to set a a value, maxInpuRadius, derived from the mapping equation to encompass the octagon of the N64. With the octagon fully encompassed by this circle, input can now abide by the mapping equation instead of having to be re-scaled as it is in the current code. Any input that exceeds the octagon is either clamped by the edge of the octagon or to maxAxis (which coincides with the cardinal vertices of the octagon). Lastly, an epsilon is added for each direction in the case that floating point error leaves a value just shy of next the whole number. Ceil or round would have been too aggressive when considering fine aiming just around the deadzone-input border.