### PR TITLE
cmake: fix the NO_ASM option

### DIFF
--- a/Source/3rdParty/CMakeLists.txt
+++ b/Source/3rdParty/CMakeLists.txt
@@ -71,7 +71,7 @@ ExternalProject_Add(mupen64plus-core
     BUILD_COMMAND ${MAKE_CMD} all -f ${M64P_CORE_DIR}/projects/unix/Makefile 
         SRCDIR=${CMAKE_CURRENT_SOURCE_DIR}/mupen64plus-core/src 
         SUBDIR=${CMAKE_CURRENT_SOURCE_DIR}/mupen64plus-core/subprojects 
-        OSD=0 NEW_DYNAREC=1 NO_ASM=$<BOOL:NO_ASM> KEYBINDINGS=0 ACCURATE_FPU=1
+        OSD=0 NEW_DYNAREC=1 NO_ASM=$<BOOL:${NO_ASM}> KEYBINDINGS=0 ACCURATE_FPU=1
         TARGET=${CORE_FILE} DEBUG=${MAKE_DEBUG}
         CC=${MAKE_CC_COMPILER} CXX=${MAKE_CXX_COMPILER}
         OPTFLAGS=${MAKE_OPTFLAGS}


### PR DESCRIPTION
Fixes: 768064a2e187282f0b29b9123ba3333c90470ddb

Apologies, I failed to commit properly yesterday and sent you the wrong patch...