### PR TITLE
Change the default audio resampler from "trivial" to "src-linear"

### DIFF
--- a/Source/RMG-Core/Settings/Settings.cpp
+++ b/Source/RMG-Core/Settings/Settings.cpp
@@ -567,7 +567,7 @@ static l_Setting get_setting(SettingsID settingId)
         setting = {SETTING_SECTION_AUDIO, "SecondaryBufferSize", 1024};
         break;
     case SettingsID::Audio_Resampler:
-        setting = {SETTING_SECTION_AUDIO, "Resampler", std::string("trivial")};
+        setting = {SETTING_SECTION_AUDIO, "Resampler", std::string("src-linear")};
         break;
     case SettingsID::Audio_Volume:
         setting = {SETTING_SECTION_AUDIO, "Volume", 100};


### PR DESCRIPTION
The trivial resampler produces rather poor audio quality. Linear is probably a more appropriate default for most users.