### PR TITLE
3rdParty: Allow disabling buttons for GC Adapter

### DIFF
--- a/Source/3rdParty/mupen64plus-input-gca/src/config.rs
+++ b/Source/3rdParty/mupen64plus-input-gca/src/config.rs
@@ -78,6 +78,7 @@ pub enum N64Button {
     CRight,
     CDown,
     CUp,
+    None,
 }
 
 impl N64Button {
@@ -97,6 +98,7 @@ impl N64Button {
             N64Button::CRight => 0x0100,
             N64Button::CDown => 0x0400,
             N64Button::CUp => 0x0800,
+            N64Button::None => 0x0000,
         }
     }
 }


### PR DESCRIPTION
As requested in #290. Adds `None` as a possible N64Button, essentially allowing buttons to be disabled.