### PR TITLE
RMG-Input: Add option to map an entire controller at once

### DIFF
--- a/Source/RMG-Input/UserInterface/Widget/ControllerWidget.cpp
+++ b/Source/RMG-Input/UserInterface/Widget/ControllerWidget.cpp
@@ -236,6 +236,7 @@ void ControllerWidget::initializeProfileButtons()
 void ControllerWidget::initializeMiscButtons()
 {
     this->inputDeviceRefreshButton->setIcon(QIcon::fromTheme("refresh-line"));
+    this->fullMapButton->setIcon(QIcon::fromTheme("speed-line"));
     this->resetButton->setIcon(QIcon::fromTheme("restart-line"));
     this->optionsButton->setIcon(QIcon::fromTheme("settings-3-line"));
     this->hotkeysButton->setIcon(QIcon::fromTheme("gamepad-line"));
@@ -383,6 +384,7 @@ void ControllerWidget::setPluggedIn(bool value)
         this->deadZoneGroupBox,
         this->deadZoneSlider,
         this->optionsButton,
+        this->fullMapButton,
         this->resetButton,
         this->hotkeysButton,
     };
@@ -835,6 +837,40 @@ void ControllerWidget::on_removeProfileButton_clicked()
     if (this->onlyLoadGameProfile)
     {
         this->LoadSettings(this->settingsSection);
+    }
+}
+
+void ControllerWidget::on_fullMapButton_clicked()
+{
+    QList<MappingButton*> mappingButtons = this->findChildren<MappingButton*>();
+
+    for(MappingButton *button : mappingButtons)
+    {
+        // Save State
+        std::vector<int> savedType = button->GetInputType();
+        std::vector<int> savedData = button->GetInputData();
+        std::vector<int> savedExtra = button->GetExtraInputData();
+        std::vector<std::string> savedText = button->GetInputText();
+
+        button->Clear();
+        button->click();
+
+        // Wait for countdown to finish (maybe there is a better way?)
+        while(!button->isEnabled())
+        {
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+        }
+
+        // Nothig was pressed
+        if(button->text() == " ")
+        {
+            // Restore State
+            for(uint i = 0; i < savedType.size(); ++i)
+            {
+                button->SetInputData((InputType)savedType[i], savedData[i], savedExtra[i], QString::fromStdString(savedText[i]));
+            }
+            break;
+        }
     }
 }
 

--- a/Source/RMG-Input/UserInterface/Widget/ControllerWidget.cpp
+++ b/Source/RMG-Input/UserInterface/Widget/ControllerWidget.cpp
@@ -23,6 +23,8 @@
 #include <SDL.h>
 #include <iostream>
 
+#include <QTime>
+
 using namespace UserInterface::Widget;
 
 ControllerWidget::ControllerWidget(QWidget* parent, EventFilter* eventFilter) : QWidget(parent)
@@ -871,6 +873,12 @@ void ControllerWidget::on_fullMapButton_clicked()
             }
             break;
         }
+
+        this->disableAllChildren();
+        QTime dieTime= QTime::currentTime().addMSecs(500);
+        while (QTime::currentTime() < dieTime)
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+        this->enableAllChildren();
     }
 }
 

--- a/Source/RMG-Input/UserInterface/Widget/ControllerWidget.hpp
+++ b/Source/RMG-Input/UserInterface/Widget/ControllerWidget.hpp
@@ -163,6 +163,7 @@ private slots:
     void on_addProfileButton_clicked();
     void on_removeProfileButton_clicked();
 
+    void on_fullMapButton_clicked();
     void on_resetButton_clicked();
     void on_optionsButton_clicked();
     void on_hotkeysButton_clicked();

--- a/Source/RMG-Input/UserInterface/Widget/ControllerWidget.ui
+++ b/Source/RMG-Input/UserInterface/Widget/ControllerWidget.ui
@@ -1241,6 +1241,13 @@
         </spacer>
        </item>
        <item>
+        <widget class="QPushButton" name="fullMapButton">
+         <property name="text">
+          <string>Full Map</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="resetButton">
          <property name="text">
           <string>Reset</string>

--- a/Source/RMG-Input/UserInterface/Widget/MappingButton.hpp
+++ b/Source/RMG-Input/UserInterface/Widget/MappingButton.hpp
@@ -35,6 +35,7 @@ struct MappingButtonInputDataType
 
 class MappingButton : public QPushButton
 {
+	Q_OBJECT
 private:
 	QSize initialSize;
 	QTimer* countDownTimer = nullptr;


### PR DESCRIPTION
Adds a button in the input options to go though all controller buttons without having to click on them manually