### PR TITLE
3rdParty: improve the hidapi check in mupen64plus-input-raphnetraw

### DIFF
--- a/Source/3rdParty/mupen64plus-input-raphnetraw/projects/unix/Makefile
+++ b/Source/3rdParty/mupen64plus-input-raphnetraw/projects/unix/Makefile
@@ -157,17 +157,11 @@ endif
 
 # test for presence of HIDLIB
 ifeq ($(origin HID_CFLAGS) $(origin HID_LDLIBS), undefined undefined)
-  HIDAPI_CONFIG = $(PKG_CONFIG) $(HIDAPI_NAME)
-  ifeq ($(shell which $(HIDAPI_CONFIG) 2>/dev/null),)
-    HIDAPI_CONFIG = $(PKG_CONFIG) $(HIDAPI_NAME)
-    ifeq ($(shell which $(HIDAPI_CONFIG) 2>/dev/null),)
-      $(error No HIDAPI development libraries found!)
-    else
-      $(warning Using HIDAPI libraries)
-    endif
+  ifeq ($(shell $(PKG_CONFIG) --modversion $(HIDAPI_NAME) 2>/dev/null),)
+    $(error No HIDAPI development libraries found!)
   endif
-  HID_CFLAGS  += $(shell $(HIDAPI_CONFIG) --cflags)
-  HID_LDLIBS += $(shell $(HIDAPI_CONFIG) --libs)
+  HID_CFLAGS = $(shell $(PKG_CONFIG) --cflags $(HIDAPI_NAME))
+  HID_LDLIBS = $(shell $(PKG_CONFIG) --libs $(HIDAPI_NAME))
 endif
 CFLAGS += $(HID_CFLAGS)
 LDLIBS += $(HID_LDLIBS)


### PR DESCRIPTION
I don't think I quite did enough in the last PR so I changed it to better match the style in mupen64plus-core.

Upstream-PR: https://github.com/raphnet/mupen64plus-input-raphnetraw/pull/17