### PR TITLE
3rdParty: remove -fno-strict-aliasing from mupen64plus-input-raphnetraw

### DIFF
--- a/Source/3rdParty/mupen64plus-input-raphnetraw/projects/unix/Makefile
+++ b/Source/3rdParty/mupen64plus-input-raphnetraw/projects/unix/Makefile
@@ -98,7 +98,7 @@ OBJDIR = _obj$(POSTFIX)
 # base CFLAGS, LDLIBS, and LDFLAGS
 OPTFLAGS ?= -O3 -flto
 WARNFLAGS ?= -Wall
-CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fno-strict-aliasing -fvisibility=hidden -I$(SRCDIR) -D_GNU_SOURCE=1
+CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fvisibility=hidden -I$(SRCDIR) -D_GNU_SOURCE=1
 LDFLAGS += $(SHARED)
 LDLIBS += -lm
 


### PR DESCRIPTION
The build succeeds with `-Werror=strict-aliasing` so this is not needed.