### PR TITLE
Update ControllerWidget.ui to fix a typo

### DIFF
--- a/Source/RMG-Input/UserInterface/Widget/ControllerWidget.ui
+++ b/Source/RMG-Input/UserInterface/Widget/ControllerWidget.ui
@@ -264,7 +264,7 @@
                </sizepolicy>
               </property>
               <property name="text">
-               <string>left:</string>
+               <string>Left:</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Fix a typo, instead of being `left:` it should be `Left:` to match with the other instances of the same.