### PR TITLE
remove rpath patch, this is not needed

### DIFF
--- a/Package/AppImage/Create.sh
+++ b/Package/AppImage/Create.sh
@@ -53,8 +53,8 @@ mv "$bin_dir/usr/share" "$bin_dir/share"
 mv "$bin_dir/usr" "$bin_dir/shared"
 
 $XVFB_RUN "$script_dir/lib4bin" --dst-dir "$bin_dir" \
-	--hard-links --patch-rpath --strip \
-	--with-hooks --strace-mode --with-sharun \
+	--hard-links --strip --with-hooks \
+	--strace-mode --with-sharun \
 	"$bin_dir/shared/bin/RMG" \
 	"$lib_dir"/libSDL* \
 	"$lib_dir"/libspeexdsp* \


### PR DESCRIPTION
This is actually not needed anymore and likely what caused #344 

See https://github.com/probonopd/PrusaSlicer.AppImage/pull/2 for more info, that user previously had issues with nvidia that were fixed by not patching rpath anymore. 

Originally the rpath patch was introduced as a method to overwrite a possible existing rpath like `/usr/lib` in the libraries that get bundled, this has priority over `--library-path` in the dynamic linker so it had to be done to avoid having the appimage try using libraries on the host. 

Now `lib4bin` will fix that if it detects that a lib comes with an absolute path rpath we don't have to patch all the libs which can break them, which means this flag is not needed anymore. 
