### PR TITLE
Ensure that netplay only connects using IPv4

### DIFF
--- a/Source/RMG/UserInterface/Dialog/Netplay/CreateNetplaySessionDialog.cpp
+++ b/Source/RMG/UserInterface/Dialog/Netplay/CreateNetplaySessionDialog.cpp
@@ -19,6 +19,7 @@
 #include <QJsonObject>
 #include <QFileInfo>
 #include <QFile>
+#include <QHostInfo>
 
 #include <RMG-Core/Settings.hpp>
 
@@ -253,7 +254,18 @@ void CreateNetplaySessionDialog::on_serverComboBox_currentIndexChanged(int index
     this->pingLineEdit->setText("Calculating...");
 
     QString address = this->serverComboBox->itemData(index).toString();
-    this->webSocket->open(QUrl(address));
+    QUrl url(address);
+    QHostInfo hostInfo = QHostInfo::fromName(url.host());
+    for (const QHostAddress &resolvedAddr : hostInfo.addresses())
+    {
+        // mupen64plus-core only supports IPv4 (due to SDL2_net)
+        if (resolvedAddr.protocol() == QAbstractSocket::IPv4Protocol)
+        {
+            url.setHost(resolvedAddr.toString());
+            this->webSocket->open(url);
+            return;
+        }
+    }
 }
 
 void CreateNetplaySessionDialog::on_nickNameLineEdit_textChanged(void)


### PR DESCRIPTION
mupen64plus-core/SDL2_net only support IPv4. If a netplay server is advertised using a DNS name (ws://myserver.com:45000 for example), it could have an AAAA/IPv6 address record. This would cause a client to try to connect over IPv6.

This change ensures it always uses the IPv4 address.

I considered having it pass the DNS name to mupen64plus-core (rather than the connected IP address), which would then cause SDL2_net to resolve the DNS name. In that case, SDL2_net would use IPv4, since it would resolve the DNS name to an IPv4 address.

The problem with that approach is that the netplay server validates TCP/UDP connections against the IPs used in the lobby (https://github.com/gopher64/gopher64-netplay-server/blob/853c817dd338f03d2eeb747db235629b345fc1d4/internal/gameServer/udp.go#L185-L190). This means that when a UDP packet comes in, it checks: "Is this from an IP address that was in the lobby?". Since the lobby was connected using IPv6, and SDL2_net would be using IPv4, the validation will fail. The client needs to use the same IP in the lobby and in the game.