### PR TITLE
README: Add missing libusb dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ cmake --install "$build_dir" --prefix="/usr"
 ```
 
 #### Windows
-* Download & Install [MSYS2](https://www.msys2.org/)
+* Download & Install [MSYS2](https://www.msys2.org/) (UCRT64)
 ```bash
-pacman -S --needed make mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-hidapi mingw-w64-ucrt-x86_64-freetype mingw-w64-ucrt-x86_64-libpng mingw-w64-ucrt-x86_64-qt6 mingw-w64-ucrt-x86_64-SDL2 mingw-w64-ucrt-x86_64-SDL2_net mingw-w64-ucrt-x86_64-speexdsp mingw-w64-ucrt-x86_64-libsamplerate mingw-w64-ucrt-x86_64-nasm mingw-w64-ucrt-x86_64-minizip mingw-w64-ucrt-x86_64-vulkan-headers git
+pacman -S --needed make mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-hidapi mingw-w64-ucrt-x86_64-freetype mingw-w64-ucrt-x86_64-libpng mingw-w64-ucrt-x86_64-qt6 mingw-w64-ucrt-x86_64-SDL2 mingw-w64-ucrt-x86_64-SDL2_net mingw-w64-ucrt-x86_64-speexdsp mingw-w64-ucrt-x86_64-libsamplerate mingw-w64-ucrt-x86_64-libusb mingw-w64-ucrt-x86_64-nasm mingw-w64-ucrt-x86_64-minizip mingw-w64-ucrt-x86_64-vulkan-headers git
 ./Source/Script/Build.sh Release
 ```
 


### PR DESCRIPTION
The `mupen64plus-input-gca` plugin can't run without `libusb-1.0.dll` being present, but is able to build fine without `libusb` being installed. If not installed, the dependency script silently fails to find/copy the DLL.