### PR TITLE
3rdParty: change minimum cmake version in discord-rpc's rapidjson

### DIFF
--- a/Source/3rdParty/discord-rpc/thirdparty/rapidjson/CMakeLists.txt
+++ b/Source/3rdParty/discord-rpc/thirdparty/rapidjson/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 if(POLICY CMP0025)
   # detect Apple's Clang
   cmake_policy(SET CMP0025 NEW)


### PR DESCRIPTION
Gentoo-Issue: https://bugs.gentoo.org/959468

I also changed it to lower case so that it will be easier for find with grep next time.