### PR TITLE
README add missing fedora dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Rosalie's Mupen GUI is licensed under the [GNU General Public License v3.0](http
   
 * Portable Fedora
   ```bash
-  sudo dnf install libusb1-devel hidapi-devel libsamplerate-devel minizip-compat-devel SDL3-devel freetype-devel mesa-libGL-devel mesa-libGLU-devel pkgconfig zlib-ng-devel binutils-devel speexdsp-devel qt6-qtbase-devel qt6-qtsvg-devel vulkan-devel gcc-c++ nasm git ninja-build
+  sudo dnf install libusb1-devel hidapi-devel libsamplerate-devel minizip-compat-devel SDL3-devel freetype-devel mesa-libGL-devel mesa-libGLU-devel pkgconfig zlib-ng-devel binutils-devel speexdsp-devel qt6-qtbase-devel qt6-qtsvg-devel qt6-qtwebsockets-devel vulkan-devel gcc-c++ nasm git ninja-build
   ./Source/Script/Build.sh Release
   ```
 


### PR DESCRIPTION
Hi, I just tried to build RMG with readme instructions on Fedora. It failed until I installed `qt6-qtwebsockets-devel`. Added it to readme command.