### PR TITLE
escape ampersand in .desktop comment to prevent markup parsing issues

### DIFF
--- a/Package/com.github.Rosalie241.RMG.desktop
+++ b/Package/com.github.Rosalie241.RMG.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=Rosalie's Mupen GUI
-Comment=An easy to use & cross-platform mupen64plus front-end written in C++ & Qt
+Comment=An easy to use &amp; cross-platform mupen64plus front-end written in C++ & Qt
 Exec=RMG %f
 TryExec=RMG
 Icon=com.github.Rosalie241.RMG


### PR DESCRIPTION
On GTK/Pango-based desktops (Budgie, GNOME, XFCE), unescaped & is treated as the start of a markup entity, causing warnings like:

`Entity did not end with a semicolon`

In Budgie specifically this eventually leads to a crash in budgie-session-binary, logging the user out.

Issue #456 