### PR TITLE
[chore] Add qt6-websockets-dev as debian building dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Rosalie's Mupen GUI is licensed under the [GNU General Public License v3.0](http
 * Portable Debian/Ubuntu
 
   ```bash
-  sudo apt-get -y install cmake libusb-1.0-0-dev libhidapi-dev libsamplerate0-dev libspeex-dev libminizip-dev libsdl3-dev libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev pkg-config zlib1g-dev binutils-dev libspeexdsp-dev qt6-base-dev libqt6svg6-dev libvulkan-dev build-essential nasm git zip ninja-build
+  sudo apt-get -y install cmake libusb-1.0-0-dev libhidapi-dev libsamplerate0-dev libspeex-dev libminizip-dev libsdl3-dev libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev pkg-config zlib1g-dev binutils-dev libspeexdsp-dev qt6-base-dev qt6-websockets-dev libqt6svg6-dev libvulkan-dev build-essential nasm git zip ninja-build
   ./Source/Script/Build.sh Release
   ```
   


### PR DESCRIPTION
On Ubuntu 25.04, `qt6-websockets-dev` didn't seem to get implicitly installed, and thus caused an error during cmake about it missing