### PR TITLE
Fix gamecube controller presence detection being broken on the official Nintendo GameCube adapter.

### DIFF
--- a/Source/RMG-Input-GCA/main.cpp
+++ b/Source/RMG-Input-GCA/main.cpp
@@ -41,6 +41,9 @@
 
 #define GCA_COMMAND_POLL 0x13
 
+#define GCA_IS_WAVEBIRD_MASK 1 << 5
+#define GCA_IS_WIRED_GC_CONTROLLER_MASK 1 << 4
+
 //
 // Local Structures
 //
@@ -76,7 +79,7 @@ struct GameCubeAdapterControllerState
             bool DpadUp    : 1;
         };
     };
-    
+
 
     union
     {
@@ -354,7 +357,7 @@ EXPORT m64p_error CALL PluginShutdown(void)
     return M64ERR_SUCCESS;
 }
 
-EXPORT m64p_error CALL PluginGetVersion(m64p_plugin_type *pluginType, int *pluginVersion, 
+EXPORT m64p_error CALL PluginGetVersion(m64p_plugin_type *pluginType, int *pluginVersion,
     int *apiVersion, const char **pluginNamePtr, int *capabilities)
 {
     if (pluginType != nullptr)
@@ -475,7 +478,7 @@ EXPORT void CALL InitiateControllers(CONTROL_INFO ControlInfo)
     for (int i = 0; i < NUM_CONTROLLERS; i++)
     {
         GameCubeAdapterControllerState state = l_ControllerState[i];
-        ControlInfo.Controls[i].Present = (state.Status > 0) ? 1 : 0;
+        ControlInfo.Controls[i].Present = state.Status & (GCA_IS_WAVEBIRD_MASK | GCA_IS_WIRED_GC_CONTROLLER_MASK) ? 1 : 0;
     }
     l_ControllerStateMutex.unlock();
 


### PR DESCRIPTION
To check if a controller is present, we were only checking if status was not 0, this is incorrect, as apparently bits 4 and 5 are what tell you if it's connected and what kind of controller (wavebird or standard) it is, see https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/InputCommon/GCAdapter.cpp#L862

In the case of my GC adapter, status was set to 0x4 when a controller was not connected.